### PR TITLE
Fix google sign in client declaration clash

### DIFF
--- a/app/src/main/java/com/fleetmanager/auth/AuthService.kt
+++ b/app/src/main/java/com/fleetmanager/auth/AuthService.kt
@@ -31,7 +31,7 @@ class AuthService @Inject constructor(
     
     val isSignedIn: Flow<Boolean> = currentUser.map { it != null }
     
-    private val googleSignInClient: GoogleSignInClient by lazy {
+    private val googleClientInternal: GoogleSignInClient by lazy {
         val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
             .requestIdToken("123456789-abcdef123456789.apps.googleusercontent.com") // Replace with your actual web client ID
             .requestEmail()
@@ -49,11 +49,11 @@ class AuthService @Inject constructor(
         }
     }
     
-    fun getGoogleSignInClient(): GoogleSignInClient = googleSignInClient
+    fun getGoogleSignInClient(): GoogleSignInClient = googleClientInternal
     
     fun signOut() {
         firebaseAuth.signOut()
-        googleSignInClient.signOut()
+        googleClientInternal.signOut()
     }
     
     fun getCurrentUserId(): String? = firebaseAuth.currentUser?.uid


### PR DESCRIPTION
Rename private `googleSignInClient` property to `googleClientInternal` in `AuthService.kt` to resolve a JVM signature clash.

The Kotlin compiler generated an implicit getter for the private `googleSignInClient` property, which had the same JVM signature as the explicit public `getGoogleSignInClient()` function, leading to a `Platform declaration clash` error during compilation. Renaming the private property avoids this conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-dada8dec-c052-4843-a9b9-cafdc9b64dc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dada8dec-c052-4843-a9b9-cafdc9b64dc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

