### PR TITLE
Fix hilt context binding error

### DIFF
--- a/app/src/main/java/com/fleetmanager/auth/AuthService.kt
+++ b/app/src/main/java/com/fleetmanager/auth/AuthService.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.tasks.await
 import android.content.Context
 import com.google.android.gms.auth.api.signin.GoogleSignIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -23,7 +24,7 @@ sealed class AuthResult {
 @Singleton
 class AuthService @Inject constructor(
     private val firebaseAuth: FirebaseAuth,
-    private val context: Context
+    @ApplicationContext private val context: Context
 ) {
     
     val currentUser: Flow<FirebaseUser?> = 


### PR DESCRIPTION
Add `@ApplicationContext` qualifier to `AuthService` constructor to resolve Hilt `MissingBinding` error for `Context`.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb66fa55-cba9-4209-a0e6-0c393444e797">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fb66fa55-cba9-4209-a0e6-0c393444e797">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

