### PR TITLE
Bypass signin and bump version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.fleetmanager"
         minSdk = 24
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/fleetmanager/MainActivity.kt
+++ b/app/src/main/java/com/fleetmanager/MainActivity.kt
@@ -5,18 +5,13 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.*
 import androidx.navigation.compose.rememberNavController
-import com.fleetmanager.auth.AuthService
 import com.fleetmanager.ui.navigation.FleetNavigation
 import com.fleetmanager.ui.navigation.Screen
 import com.fleetmanager.ui.theme.FleetManagerTheme
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-    
-    @Inject
-    lateinit var authService: AuthService
     
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -24,13 +19,8 @@ class MainActivity : ComponentActivity() {
         setContent {
             FleetManagerTheme {
                 val navController = rememberNavController()
-                val isSignedIn by authService.isSignedIn.collectAsState(initial = false)
-                
-                val startDestination = if (isSignedIn) {
-                    Screen.EntryList.route
-                } else {
-                    Screen.SignIn.route
-                }
+                // Bypass signin screen for now - go directly to EntryList
+                val startDestination = Screen.EntryList.route
                 
                 FleetNavigation(
                     navController = navController,


### PR DESCRIPTION
Bypass sign-in screen to directly access the entry list and bump app version for easier installation.

The sign-in functionality is temporarily disabled to allow immediate access to the `EntryListScreen` for development purposes. The app version was incremented to facilitate side-by-side installation.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fe64c20-8c63-4adc-b98c-d50697ce7a3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0fe64c20-8c63-4adc-b98c-d50697ce7a3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

