### PR TITLE
Optimize build and add bottom navigation

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   build:

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -4,11 +4,15 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
     name: Build APK
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -19,39 +23,22 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
+          cache: 'gradle'
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Cache Android SDK
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ env.ANDROID_SDK_ROOT }}
-            ~/.android
-          key: ${{ runner.os }}-android-sdk-${{ hashFiles('**/build.gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-android-sdk-
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
       - name: Build APK with Gradle
-        run: ./gradlew :app:assembleDebug --build-cache --parallel --daemon
+        run: ./gradlew :app:assembleDebug --build-cache --parallel --daemon --no-configuration-cache
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
-          name: app-debug-${{ github.sha }}
+          name: app-debug-${{ github.run_number }}
           path: app/build/outputs/apk/debug/app-debug.apk
-          retention-days: 30
+          retention-days: 7
+          compression-level: 6

--- a/app/src/main/java/com/fleetmanager/MainActivity.kt
+++ b/app/src/main/java/com/fleetmanager/MainActivity.kt
@@ -5,7 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.*
 import androidx.navigation.compose.rememberNavController
-import com.fleetmanager.ui.navigation.FleetNavigation
+import com.fleetmanager.ui.navigation.MainScreenWithBottomNav
 import com.fleetmanager.ui.navigation.Screen
 import com.fleetmanager.ui.theme.FleetManagerTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -19,12 +19,9 @@ class MainActivity : ComponentActivity() {
         setContent {
             FleetManagerTheme {
                 val navController = rememberNavController()
-                // Bypass signin screen for now - go directly to EntryList
-                val startDestination = Screen.EntryList.route
                 
-                FleetNavigation(
-                    navController = navController,
-                    startDestination = startDestination
+                MainScreenWithBottomNav(
+                    navController = navController
                 )
             }
         }

--- a/app/src/main/java/com/fleetmanager/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/fleetmanager/ui/components/CommonComponents.kt
@@ -1,0 +1,311 @@
+package com.fleetmanager.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+// Screen Header Component
+@Composable
+fun ScreenHeader(
+    title: String,
+    modifier: Modifier = Modifier,
+    actions: @Composable RowScope.() -> Unit = {}
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold
+        )
+        
+        Row(content = actions)
+    }
+}
+
+// Stat Card Component
+@Composable
+fun StatCard(
+    icon: ImageVector,
+    value: String,
+    label: String,
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null
+) {
+    val cardModifier = if (onClick != null) {
+        modifier.then(Modifier.clickable { onClick() })
+    } else modifier
+
+    Card(
+        modifier = cardModifier.width(160.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp)
+            )
+            Text(
+                text = value,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.outline
+            )
+        }
+    }
+}
+
+// Stats Grid Component
+@Composable
+fun StatsGrid(
+    stats: List<StatItem>,
+    modifier: Modifier = Modifier
+) {
+    LazyRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        contentPadding = PaddingValues(horizontal = 0.dp)
+    ) {
+        items(stats) { stat ->
+            StatCard(
+                icon = stat.icon,
+                value = stat.value,
+                label = stat.label,
+                onClick = stat.onClick
+            )
+        }
+    }
+}
+
+// Action Button Component
+@Composable
+fun ActionButton(
+    text: String,
+    icon: ImageVector,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isPrimary: Boolean = true
+) {
+    if (isPrimary) {
+        ElevatedButton(
+            onClick = onClick,
+            modifier = modifier
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(text)
+        }
+    } else {
+        OutlinedButton(
+            onClick = onClick,
+            modifier = modifier
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(text)
+        }
+    }
+}
+
+// Quick Actions Row Component
+@Composable
+fun QuickActionsRow(
+    actions: List<ActionItem>,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        actions.forEach { action ->
+            ActionButton(
+                text = action.text,
+                icon = action.icon,
+                onClick = action.onClick,
+                isPrimary = action.isPrimary,
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+// Section Header Component
+@Composable
+fun SectionHeader(
+    title: String,
+    modifier: Modifier = Modifier,
+    action: @Composable (() -> Unit)? = null
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.SemiBold
+        )
+        action?.invoke()
+    }
+}
+
+// Empty State Component
+@Composable
+fun EmptyState(
+    icon: ImageVector,
+    title: String,
+    description: String,
+    actionText: String? = null,
+    onActionClick: (() -> Unit)? = null,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.outline
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.outline
+            )
+            
+            if (actionText != null && onActionClick != null) {
+                Spacer(modifier = Modifier.height(16.dp))
+                Button(onClick = onActionClick) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(actionText)
+                }
+            }
+        }
+    }
+}
+
+// Status Card Component (for sync, errors, etc.)
+@Composable
+fun StatusCard(
+    type: StatusType,
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    val (containerColor, contentColor, icon) = when (type) {
+        StatusType.Loading -> Triple(
+            MaterialTheme.colorScheme.primaryContainer,
+            MaterialTheme.colorScheme.onPrimaryContainer,
+            Icons.Default.Sync
+        )
+        StatusType.Error -> Triple(
+            MaterialTheme.colorScheme.errorContainer,
+            MaterialTheme.colorScheme.onErrorContainer,
+            Icons.Default.Error
+        )
+        StatusType.Success -> Triple(
+            MaterialTheme.colorScheme.primaryContainer,
+            MaterialTheme.colorScheme.onPrimaryContainer,
+            Icons.Default.CheckCircle
+        )
+    }
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = containerColor)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (type == StatusType.Loading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp),
+                    strokeWidth = 2.dp,
+                    color = contentColor
+                )
+            } else {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = contentColor,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+            Spacer(modifier = Modifier.width(16.dp))
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = contentColor
+            )
+        }
+    }
+}
+
+// Data Classes
+data class StatItem(
+    val icon: ImageVector,
+    val value: String,
+    val label: String,
+    val onClick: (() -> Unit)? = null
+)
+
+data class ActionItem(
+    val text: String,
+    val icon: ImageVector,
+    val onClick: () -> Unit,
+    val isPrimary: Boolean = true
+)
+
+enum class StatusType {
+    Loading, Error, Success
+}

--- a/app/src/main/java/com/fleetmanager/ui/components/ListComponents.kt
+++ b/app/src/main/java/com/fleetmanager/ui/components/ListComponents.kt
@@ -1,0 +1,207 @@
+package com.fleetmanager.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+// Generic List Item Component
+@Composable
+fun ListItemCard(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable { onClick() },
+        shape = RoundedCornerShape(12.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            content = content
+        )
+    }
+}
+
+// Entry Summary Card Component
+@Composable
+fun EntrySummaryCard(
+    title: String,
+    subtitle: String,
+    date: String,
+    amount: Double,
+    additionalInfo: String? = null,
+    isSynced: Boolean = true,
+    onClick: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    ListItemCard(
+        modifier = modifier,
+        onClick = onClick
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.Top
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = date,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = "$${String.format("%.2f", amount)}",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                if (!isSynced) {
+                    Text(
+                        text = "⏳ Syncing",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.secondary
+                    )
+                }
+                additionalInfo?.let { info ->
+                    Text(
+                        text = info,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.outline
+                    )
+                }
+            }
+        }
+    }
+}
+
+// Activity Item Component (for recent activities)
+@Composable
+fun ActivityItemCard(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    value: String,
+    valueLabel: String,
+    onClick: () -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    ListItemCard(
+        modifier = modifier,
+        onClick = onClick
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(40.dp)
+            )
+            
+            Spacer(modifier = Modifier.width(16.dp))
+            
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline
+                )
+            }
+            
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = value,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = valueLabel,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline
+                )
+            }
+        }
+    }
+}
+
+// Earnings Chips Component
+@Composable
+fun EarningsChips(
+    earnings: List<EarningItem>,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        earnings.forEach { earning ->
+            if (earning.amount > 0) {
+                EarningChip(
+                    label = earning.label,
+                    amount = earning.amount
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EarningChip(
+    label: String,
+    amount: Double
+) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer
+        ),
+        shape = RoundedCornerShape(20.dp)
+    ) {
+        Text(
+            text = "$label: $${String.format("%.0f", amount)}",
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSecondaryContainer
+        )
+    }
+}
+
+// Data Classes
+data class EarningItem(
+    val label: String,
+    val amount: Double
+)

--- a/app/src/main/java/com/fleetmanager/ui/components/SettingsComponents.kt
+++ b/app/src/main/java/com/fleetmanager/ui/components/SettingsComponents.kt
@@ -1,0 +1,108 @@
+package com.fleetmanager.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+// Settings Section Component
+@Composable
+fun SettingsSection(
+    title: String,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        Card(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(
+                modifier = Modifier.padding(vertical = 8.dp),
+                content = content
+            )
+        }
+    }
+}
+
+// Settings Item Component
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsItem(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+    trailing: @Composable (() -> Unit)? = null
+) {
+    Surface(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp)
+            )
+            
+            Spacer(modifier = Modifier.width(16.dp))
+            
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline
+                )
+            }
+            
+            trailing?.invoke()
+        }
+    }
+}
+
+// Settings Toggle Item Component
+@Composable
+fun SettingsToggleItem(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    SettingsItem(
+        icon = icon,
+        title = title,
+        subtitle = subtitle,
+        modifier = modifier,
+        trailing = {
+            Switch(
+                checked = checked,
+                onCheckedChange = onCheckedChange
+            )
+        }
+    )
+}

--- a/app/src/main/java/com/fleetmanager/ui/navigation/FleetNavigation.kt
+++ b/app/src/main/java/com/fleetmanager/ui/navigation/FleetNavigation.kt
@@ -1,24 +1,49 @@
 package com.fleetmanager.ui.navigation
 
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.navigation.NavDestination.Companion.hierarchy
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.navArgument
 import androidx.navigation.NavType
 import com.fleetmanager.ui.screens.auth.SignInScreen
+import com.fleetmanager.ui.screens.dashboard.DashboardScreen
 import com.fleetmanager.ui.screens.entry.AddEntryScreen
 import com.fleetmanager.ui.screens.entry.EntryDetailScreen
 import com.fleetmanager.ui.screens.entry.EntryListScreen
+import com.fleetmanager.ui.screens.settings.SettingsScreen
 
 sealed class Screen(val route: String) {
     object SignIn : Screen("sign_in")
-    object EntryList : Screen("entry_list")
+    object Dashboard : Screen("dashboard")
+    object History : Screen("history") // This will be the EntryList screen
+    object Settings : Screen("settings")
     object AddEntry : Screen("add_entry")
     object EntryDetail : Screen("entry_detail/{entryId}") {
         fun createRoute(entryId: String) = "entry_detail/$entryId"
     }
 }
+
+data class BottomNavItem(
+    val screen: Screen,
+    val title: String,
+    val icon: ImageVector
+)
+
+val bottomNavItems = listOf(
+    BottomNavItem(Screen.Dashboard, "Dashboard", Icons.Default.Dashboard),
+    BottomNavItem(Screen.History, "History", Icons.Default.History),
+    BottomNavItem(Screen.Settings, "Settings", Icons.Default.Settings)
+)
 
 @Composable
 fun FleetNavigation(
@@ -32,14 +57,22 @@ fun FleetNavigation(
         composable(Screen.SignIn.route) {
             SignInScreen(
                 onSignInSuccess = {
-                    navController.navigate(Screen.EntryList.route) {
+                    navController.navigate(Screen.Dashboard.route) {
                         popUpTo(Screen.SignIn.route) { inclusive = true }
                     }
                 }
             )
         }
         
-        composable(Screen.EntryList.route) {
+        composable(Screen.Dashboard.route) {
+            DashboardScreen(
+                onAddEntryClick = {
+                    navController.navigate(Screen.AddEntry.route)
+                }
+            )
+        }
+        
+        composable(Screen.History.route) {
             EntryListScreen(
                 onAddEntryClick = {
                     navController.navigate(Screen.AddEntry.route)
@@ -48,6 +81,132 @@ fun FleetNavigation(
                     navController.navigate(Screen.EntryDetail.createRoute(entryId))
                 }
             )
+        }
+        
+        composable(Screen.Settings.route) {
+            SettingsScreen()
+        }
+        
+        composable(Screen.AddEntry.route) {
+            AddEntryScreen(
+                onNavigateBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
+        
+        composable(
+            route = Screen.EntryDetail.route,
+            arguments = listOf(navArgument("entryId") { type = NavType.StringType })
+        ) { backStackEntry ->
+            val entryId = backStackEntry.arguments?.getString("entryId") ?: ""
+            EntryDetailScreen(
+                entryId = entryId,
+                onNavigateBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
+    }
+}
+
+@Composable
+fun MainScreenWithBottomNav(
+    navController: NavHostController
+) {
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentDestination = navBackStackEntry?.destination
+    
+    // Check if we should show bottom navigation
+    val showBottomNav = currentDestination?.route in bottomNavItems.map { it.screen.route }
+    
+    Scaffold(
+        bottomBar = {
+            if (showBottomNav) {
+                NavigationBar {
+                    bottomNavItems.forEach { item ->
+                        NavigationBarItem(
+                            icon = { 
+                                Icon(
+                                    imageVector = item.icon,
+                                    contentDescription = item.title
+                                )
+                            },
+                            label = { Text(item.title) },
+                            selected = currentDestination?.hierarchy?.any { 
+                                it.route == item.screen.route 
+                            } == true,
+                            onClick = {
+                                navController.navigate(item.screen.route) {
+                                    // Pop up to the start destination of the graph to
+                                    // avoid building up a large stack of destinations
+                                    // on the back stack as users select items
+                                    popUpTo(navController.graph.findStartDestination().id) {
+                                        saveState = true
+                                    }
+                                    // Avoid multiple copies of the same destination when
+                                    // reselecting the same item
+                                    launchSingleTop = true
+                                    // Restore state when reselecting a previously selected item
+                                    restoreState = true
+                                }
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    ) { innerPadding ->
+        FleetNavigation(
+            navController = navController,
+            startDestination = Screen.Dashboard.route,
+            modifier = Modifier.padding(innerPadding)
+        )
+    }
+}
+
+@Composable
+fun FleetNavigation(
+    navController: NavHostController,
+    startDestination: String,
+    modifier: Modifier = Modifier
+) {
+    NavHost(
+        navController = navController,
+        startDestination = startDestination,
+        modifier = modifier
+    ) {
+        composable(Screen.SignIn.route) {
+            SignInScreen(
+                onSignInSuccess = {
+                    navController.navigate(Screen.Dashboard.route) {
+                        popUpTo(Screen.SignIn.route) { inclusive = true }
+                    }
+                }
+            )
+        }
+        
+        composable(Screen.Dashboard.route) {
+            DashboardScreen(
+                onAddEntryClick = {
+                    navController.navigate(Screen.AddEntry.route)
+                }
+            )
+        }
+        
+        composable(Screen.History.route) {
+            EntryListScreen(
+                onAddEntryClick = {
+                    navController.navigate(Screen.AddEntry.route)
+                },
+                onEntryClick = { entryId ->
+                    navController.navigate(Screen.EntryDetail.createRoute(entryId))
+                }
+            )
+        }
+        
+        composable(Screen.Settings.route) {
+            SettingsScreen()
         }
         
         composable(Screen.AddEntry.route) {

--- a/app/src/main/java/com/fleetmanager/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/dashboard/DashboardScreen.kt
@@ -2,19 +2,15 @@ package com.fleetmanager.ui.screens.dashboard
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
-import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.fleetmanager.ui.components.*
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DashboardScreen(
     onAddEntryClick: () -> Unit,
@@ -29,199 +25,71 @@ fun DashboardScreen(
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         item {
-            Text(
-                text = "Dashboard",
-                style = MaterialTheme.typography.headlineMedium,
-                fontWeight = FontWeight.Bold
-            )
+            ScreenHeader(title = "Dashboard")
         }
 
-        // Quick Stats Cards
+        // Quick Stats
         item {
-            LazyRow(
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                contentPadding = PaddingValues(horizontal = 0.dp)
-            ) {
-                items(uiState.quickStats) { stat ->
-                    QuickStatCard(stat = stat)
-                }
-            }
+            StatsGrid(stats = uiState.quickStats)
         }
 
         // Quick Actions
         item {
-            Text(
-                text = "Quick Actions",
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.SemiBold
-            )
+            SectionHeader(title = "Quick Actions")
         }
 
         item {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                ElevatedButton(
-                    onClick = onAddEntryClick,
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Add,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp)
+            QuickActionsRow(
+                actions = listOf(
+                    ActionItem(
+                        text = "Add Entry",
+                        icon = Icons.Default.Add,
+                        onClick = onAddEntryClick,
+                        isPrimary = true
+                    ),
+                    ActionItem(
+                        text = "Sync",
+                        icon = Icons.Default.Refresh,
+                        onClick = { viewModel.syncNow() },
+                        isPrimary = false
                     )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text("Add Entry")
-                }
-
-                OutlinedButton(
-                    onClick = { /* TODO: Implement sync */ },
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Refresh,
-                        contentDescription = null,
-                        modifier = Modifier.size(18.dp)
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text("Sync")
-                }
-            }
+                )
+            )
         }
 
         // Recent Activity
         item {
-            Text(
-                text = "Recent Activity",
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.SemiBold
-            )
-        }
-
-        items(uiState.recentEntries) { entry ->
-            RecentEntryCard(entry = entry)
+            SectionHeader(title = "Recent Activity")
         }
 
         if (uiState.recentEntries.isEmpty()) {
             item {
-                Card(
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(24.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Assignment,
-                            contentDescription = null,
-                            modifier = Modifier.size(48.dp),
-                            tint = MaterialTheme.colorScheme.outline
-                        )
-                        Spacer(modifier = Modifier.height(16.dp))
-                        Text(
-                            text = "No entries yet",
-                            style = MaterialTheme.typography.titleMedium
-                        )
-                        Text(
-                            text = "Start by adding your first daily entry",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.outline
-                        )
-                        Spacer(modifier = Modifier.height(16.dp))
-                        Button(onClick = onAddEntryClick) {
-                            Icon(
-                                imageVector = Icons.Default.Add,
-                                contentDescription = null,
-                                modifier = Modifier.size(18.dp)
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text("Add Entry")
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun QuickStatCard(stat: QuickStat) {
-    Card(
-        modifier = Modifier.width(160.dp)
-    ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            Icon(
-                imageVector = stat.icon,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(24.dp)
-            )
-            Text(
-                text = stat.value,
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold
-            )
-            Text(
-                text = stat.label,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.outline
-            )
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun RecentEntryCard(entry: RecentEntry) {
-    Card(
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(
-                imageVector = Icons.Default.DirectionsCar,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(40.dp)
-            )
-            
-            Spacer(modifier = Modifier.width(16.dp))
-            
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = entry.driverName,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Medium
-                )
-                Text(
-                    text = entry.date,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.outline
+                EmptyState(
+                    icon = Icons.Default.Assignment,
+                    title = "No entries yet",
+                    description = "Start by adding your first daily entry",
+                    actionText = "Add Entry",
+                    onActionClick = onAddEntryClick
                 )
             }
-            
-            Column(horizontalAlignment = Alignment.End) {
-                Text(
-                    text = "$${entry.totalEarnings}",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.primary
+        } else {
+            items(uiState.recentEntries) { entry ->
+                ActivityItemCard(
+                    icon = Icons.Default.DirectionsCar,
+                    title = entry.driverName,
+                    subtitle = entry.date,
+                    value = "$${String.format("%.0f", entry.totalEarnings)}",
+                    valueLabel = "${entry.totalRides} rides"
                 )
-                Text(
-                    text = "${entry.totalRides} rides",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.outline
+            }
+        }
+
+        // Show sync status if needed
+        uiState.error?.let { error ->
+            item {
+                StatusCard(
+                    type = StatusType.Error,
+                    message = error
                 )
             }
         }

--- a/app/src/main/java/com/fleetmanager/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/dashboard/DashboardScreen.kt
@@ -1,0 +1,229 @@
+package com.fleetmanager.ui.screens.dashboard
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DashboardScreen(
+    onAddEntryClick: () -> Unit,
+    viewModel: DashboardViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            Text(
+                text = "Dashboard",
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold
+            )
+        }
+
+        // Quick Stats Cards
+        item {
+            LazyRow(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                contentPadding = PaddingValues(horizontal = 0.dp)
+            ) {
+                items(uiState.quickStats) { stat ->
+                    QuickStatCard(stat = stat)
+                }
+            }
+        }
+
+        // Quick Actions
+        item {
+            Text(
+                text = "Quick Actions",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                ElevatedButton(
+                    onClick = onAddEntryClick,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Add Entry")
+                }
+
+                OutlinedButton(
+                    onClick = { /* TODO: Implement sync */ },
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Refresh,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Sync")
+                }
+            }
+        }
+
+        // Recent Activity
+        item {
+            Text(
+                text = "Recent Activity",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold
+            )
+        }
+
+        items(uiState.recentEntries) { entry ->
+            RecentEntryCard(entry = entry)
+        }
+
+        if (uiState.recentEntries.isEmpty()) {
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(24.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Assignment,
+                            contentDescription = null,
+                            modifier = Modifier.size(48.dp),
+                            tint = MaterialTheme.colorScheme.outline
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = "No entries yet",
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        Text(
+                            text = "Start by adding your first daily entry",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.outline
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Button(onClick = onAddEntryClick) {
+                            Icon(
+                                imageVector = Icons.Default.Add,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp)
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text("Add Entry")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun QuickStatCard(stat: QuickStat) {
+    Card(
+        modifier = Modifier.width(160.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Icon(
+                imageVector = stat.icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp)
+            )
+            Text(
+                text = stat.value,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = stat.label,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.outline
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RecentEntryCard(entry: RecentEntry) {
+    Card(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.DirectionsCar,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(40.dp)
+            )
+            
+            Spacer(modifier = Modifier.width(16.dp))
+            
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = entry.driverName,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium
+                )
+                Text(
+                    text = entry.date,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline
+                )
+            }
+            
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = "$${entry.totalEarnings}",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = "${entry.totalRides} rides",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/fleetmanager/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/dashboard/DashboardViewModel.kt
@@ -1,0 +1,119 @@
+package com.fleetmanager.ui.screens.dashboard
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.fleetmanager.data.repository.FleetRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class QuickStat(
+    val icon: ImageVector,
+    val value: String,
+    val label: String
+)
+
+data class RecentEntry(
+    val id: String,
+    val driverName: String,
+    val date: String,
+    val totalEarnings: Double,
+    val totalRides: Int
+)
+
+data class DashboardUiState(
+    val quickStats: List<QuickStat> = emptyList(),
+    val recentEntries: List<RecentEntry> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null
+)
+
+@HiltViewModel
+class DashboardViewModel @Inject constructor(
+    private val repository: FleetRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(DashboardUiState())
+    val uiState: StateFlow<DashboardUiState> = _uiState.asStateFlow()
+
+    init {
+        loadDashboardData()
+    }
+
+    private fun loadDashboardData() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true)
+
+            try {
+                // Combine flows for real-time updates
+                combine(
+                    repository.getAllEntries(),
+                    repository.getAllDrivers()
+                ) { entries, drivers ->
+                    val driverMap = drivers.associateBy { it.id }
+                    
+                    // Calculate quick stats
+                    val totalEarnings = entries.sumOf { it.totalEarnings }
+                    val totalEntries = entries.size
+                    val activeDrivers = entries.distinctBy { it.driverId }.size
+                    val avgEarningsPerEntry = if (totalEntries > 0) totalEarnings / totalEntries else 0.0
+
+                    val quickStats = listOf(
+                        QuickStat(
+                            icon = Icons.Default.AttachMoney,
+                            value = "$${String.format("%.0f", totalEarnings)}",
+                            label = "Total Earnings"
+                        ),
+                        QuickStat(
+                            icon = Icons.Default.Assignment,
+                            value = totalEntries.toString(),
+                            label = "Total Entries"
+                        ),
+                        QuickStat(
+                            icon = Icons.Default.People,
+                            value = activeDrivers.toString(),
+                            label = "Active Drivers"
+                        ),
+                        QuickStat(
+                            icon = Icons.Default.TrendingUp,
+                            value = "$${String.format("%.0f", avgEarningsPerEntry)}",
+                            label = "Avg per Entry"
+                        )
+                    )
+
+                    // Get recent entries (last 5)
+                    val recentEntries = entries
+                        .sortedByDescending { it.date }
+                        .take(5)
+                        .map { entry ->
+                            val driver = driverMap[entry.driverId]
+                            RecentEntry(
+                                id = entry.id,
+                                driverName = driver?.name ?: "Unknown Driver",
+                                date = entry.date,
+                                totalEarnings = entry.totalEarnings,
+                                totalRides = entry.uberRides + entry.yangoRides + entry.privateRides
+                            )
+                        }
+
+                    DashboardUiState(
+                        quickStats = quickStats,
+                        recentEntries = recentEntries,
+                        isLoading = false
+                    )
+                }.collect { newState ->
+                    _uiState.value = newState
+                }
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    isLoading = false,
+                    error = e.message
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/fleetmanager/ui/screens/entry/EntryListScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/entry/EntryListScreen.kt
@@ -29,25 +29,39 @@ fun EntryListScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.entries)) }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        // Header
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "History",
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold
             )
-        },
-        floatingActionButton = {
+            
             FloatingActionButton(
                 onClick = onAddEntryClick,
-                modifier = Modifier.padding(16.dp)
+                modifier = Modifier.size(56.dp)
             ) {
-                Icon(Icons.Default.Add, contentDescription = stringResource(R.string.add_entry))
+                Icon(
+                    Icons.Default.Add, 
+                    contentDescription = "Add entry",
+                    modifier = Modifier.size(24.dp)
+                )
             }
         }
-    ) { paddingValues ->
+        
+        Spacer(modifier = Modifier.height(16.dp))
+        
         Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
+            modifier = Modifier.fillMaxSize()
         ) {
             when {
                 uiState.isLoading -> {
@@ -80,7 +94,7 @@ fun EntryListScreen(
                 else -> {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(16.dp),
+                        contentPadding = PaddingValues(0.dp),
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         items(uiState.entries) { entry ->

--- a/app/src/main/java/com/fleetmanager/ui/screens/entry/EntryListScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/entry/EntryListScreen.kt
@@ -1,26 +1,21 @@
 package com.fleetmanager.ui.screens.entry
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.fleetmanager.R
 import com.fleetmanager.data.model.DailyEntry
+import com.fleetmanager.ui.components.*
 import java.text.SimpleDateFormat
 import java.util.*
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EntryListScreen(
     onAddEntryClick: () -> Unit,
@@ -29,81 +24,60 @@ fun EntryListScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     
-    Column(
+    LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        // Header
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = "History",
-                style = MaterialTheme.typography.headlineMedium,
-                fontWeight = FontWeight.Bold
+        item {
+            ScreenHeader(
+                title = "History",
+                actions = {
+                    FloatingActionButton(
+                        onClick = onAddEntryClick,
+                        modifier = Modifier.size(56.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.Add, 
+                            contentDescription = "Add entry",
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                }
             )
-            
-            FloatingActionButton(
-                onClick = onAddEntryClick,
-                modifier = Modifier.size(56.dp)
-            ) {
-                Icon(
-                    Icons.Default.Add, 
-                    contentDescription = "Add entry",
-                    modifier = Modifier.size(24.dp)
-                )
-            }
         }
         
-        Spacer(modifier = Modifier.height(16.dp))
-        
-        Box(
-            modifier = Modifier.fillMaxSize()
-        ) {
-            when {
-                uiState.isLoading -> {
-                    CircularProgressIndicator(
-                        modifier = Modifier.align(Alignment.Center)
+        when {
+            uiState.isLoading -> {
+                item {
+                    Box(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+            }
+            
+            uiState.entries.isEmpty() -> {
+                item {
+                    EmptyState(
+                        icon = Icons.Default.Assignment,
+                        title = "No entries yet",
+                        description = "Add your first daily entry to get started",
+                        actionText = "Add Entry",
+                        onActionClick = onAddEntryClick
                     )
                 }
-                
-                uiState.entries.isEmpty() -> {
-                    Column(
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .padding(32.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-                        Text(
-                            text = "No entries yet",
-                            style = MaterialTheme.typography.headlineSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        Spacer(modifier = Modifier.height(8.dp))
-                        Text(
-                            text = "Add your first daily entry to get started",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                }
-                
-                else -> {
-                    LazyColumn(
-                        modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(0.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        items(uiState.entries) { entry ->
-                            EntryCard(
-                                entry = entry,
-                                onClick = { onEntryClick(entry.id) }
-                            )
-                        }
-                    }
+            }
+            
+            else -> {
+                items(uiState.entries) { entry ->
+                    EntryCard(
+                        entry = entry,
+                        onClick = { onEntryClick(entry.id) }
+                    )
                 }
             }
         }
@@ -117,105 +91,64 @@ fun EntryCard(
 ) {
     val dateFormatter = SimpleDateFormat("MMM dd, yyyy", Locale.getDefault())
     
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable { onClick() },
-        shape = RoundedCornerShape(12.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
+    ListItemCard(onClick = onClick) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.Top
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.Top
-            ) {
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = entry.driverName,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold
-                    )
-                    Text(
-                        text = entry.vehicle,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Text(
-                        text = dateFormatter.format(entry.date),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                
-                Column(horizontalAlignment = Alignment.End) {
-                    Text(
-                        text = "$${String.format("%.2f", entry.totalEarnings)}",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                    if (!entry.isSynced) {
-                        Text(
-                            text = "⏳ Syncing",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.secondary
-                        )
-                    }
-                }
-            }
-            
-            if (entry.notes.isNotEmpty()) {
-                Spacer(modifier = Modifier.height(8.dp))
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = entry.notes,
+                    text = entry.driverName,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = entry.vehicle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = dateFormatter.format(entry.date),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
             
-            Spacer(modifier = Modifier.height(8.dp))
-            
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                EarningsChip(
-                    label = "Uber",
-                    amount = entry.uberEarnings
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = "$${String.format("%.2f", entry.totalEarnings)}",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.primary
                 )
-                EarningsChip(
-                    label = "Yango",
-                    amount = entry.yangoEarnings
-                )
-                EarningsChip(
-                    label = "Private",
-                    amount = entry.privateJobsEarnings
-                )
+                if (!entry.isSynced) {
+                    Text(
+                        text = "⏳ Syncing",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.secondary
+                    )
+                }
             }
         }
-    }
-}
-
-@Composable
-fun EarningsChip(label: String, amount: Double) {
-    if (amount > 0) {
-        Card(
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.secondaryContainer
-            ),
-            shape = RoundedCornerShape(20.dp)
-        ) {
+        
+        if (entry.notes.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(8.dp))
             Text(
-                text = "$label: $${String.format("%.0f", amount)}",
-                modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+                text = entry.notes,
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSecondaryContainer
+                color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
+        
+        Spacer(modifier = Modifier.height(8.dp))
+        
+        EarningsChips(
+            earnings = listOf(
+                EarningItem("Uber", entry.uberEarnings),
+                EarningItem("Yango", entry.yangoEarnings),
+                EarningItem("Private", entry.privateJobsEarnings)
+            )
+        )
     }
 }

--- a/app/src/main/java/com/fleetmanager/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/settings/SettingsScreen.kt
@@ -1,0 +1,298 @@
+package com.fleetmanager.ui.screens.settings
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            Text(
+                text = "Settings",
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold
+            )
+        }
+
+        // Account Section
+        item {
+            SettingsSection(title = "Account") {
+                SettingsItem(
+                    icon = Icons.Default.Person,
+                    title = "Profile",
+                    subtitle = "Manage your account details",
+                    onClick = { /* TODO: Navigate to profile */ }
+                )
+                
+                SettingsItem(
+                    icon = Icons.Default.Logout,
+                    title = "Sign Out",
+                    subtitle = "Sign out of your account",
+                    onClick = { viewModel.signOut() }
+                )
+            }
+        }
+
+        // Data & Sync Section
+        item {
+            SettingsSection(title = "Data & Sync") {
+                SettingsItem(
+                    icon = Icons.Default.Sync,
+                    title = "Auto Sync",
+                    subtitle = if (uiState.autoSyncEnabled) "Enabled" else "Disabled",
+                    trailing = {
+                        Switch(
+                            checked = uiState.autoSyncEnabled,
+                            onCheckedChange = { viewModel.toggleAutoSync(it) }
+                        )
+                    }
+                )
+                
+                SettingsItem(
+                    icon = Icons.Default.CloudSync,
+                    title = "Sync Now",
+                    subtitle = "Last synced: ${uiState.lastSyncTime}",
+                    onClick = { viewModel.syncNow() }
+                )
+                
+                SettingsItem(
+                    icon = Icons.Default.Storage,
+                    title = "Data Export",
+                    subtitle = "Export your data to CSV",
+                    onClick = { viewModel.exportData() }
+                )
+            }
+        }
+
+        // Notifications Section
+        item {
+            SettingsSection(title = "Notifications") {
+                SettingsItem(
+                    icon = Icons.Default.Notifications,
+                    title = "Push Notifications",
+                    subtitle = if (uiState.notificationsEnabled) "Enabled" else "Disabled",
+                    trailing = {
+                        Switch(
+                            checked = uiState.notificationsEnabled,
+                            onCheckedChange = { viewModel.toggleNotifications(it) }
+                        )
+                    }
+                )
+                
+                SettingsItem(
+                    icon = Icons.Default.Schedule,
+                    title = "Daily Reminders",
+                    subtitle = if (uiState.dailyRemindersEnabled) "Enabled" else "Disabled",
+                    trailing = {
+                        Switch(
+                            checked = uiState.dailyRemindersEnabled,
+                            onCheckedChange = { viewModel.toggleDailyReminders(it) }
+                        )
+                    }
+                )
+            }
+        }
+
+        // App Section
+        item {
+            SettingsSection(title = "App") {
+                SettingsItem(
+                    icon = Icons.Default.Palette,
+                    title = "Theme",
+                    subtitle = uiState.selectedTheme,
+                    onClick = { /* TODO: Show theme picker */ }
+                )
+                
+                SettingsItem(
+                    icon = Icons.Default.Language,
+                    title = "Language",
+                    subtitle = "English",
+                    onClick = { /* TODO: Show language picker */ }
+                )
+                
+                SettingsItem(
+                    icon = Icons.Default.Info,
+                    title = "About",
+                    subtitle = "Version ${uiState.appVersion}",
+                    onClick = { /* TODO: Show about dialog */ }
+                )
+            }
+        }
+
+        // Support Section
+        item {
+            SettingsSection(title = "Support") {
+                SettingsItem(
+                    icon = Icons.Default.Help,
+                    title = "Help & FAQ",
+                    subtitle = "Get help and find answers",
+                    onClick = { /* TODO: Open help */ }
+                )
+                
+                SettingsItem(
+                    icon = Icons.Default.Feedback,
+                    title = "Send Feedback",
+                    subtitle = "Help us improve the app",
+                    onClick = { /* TODO: Open feedback */ }
+                )
+                
+                SettingsItem(
+                    icon = Icons.Default.BugReport,
+                    title = "Report a Bug",
+                    subtitle = "Report issues or problems",
+                    onClick = { /* TODO: Open bug report */ }
+                )
+            }
+        }
+
+        // Show sync status if syncing
+        if (uiState.isSyncing) {
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer
+                    )
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(24.dp),
+                            strokeWidth = 2.dp
+                        )
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Text(
+                            text = "Syncing data...",
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                    }
+                }
+            }
+        }
+
+        // Show error if any
+        uiState.error?.let { error ->
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer
+                    )
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Error,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onErrorContainer
+                        )
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Text(
+                            text = error,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onErrorContainer
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingsSection(
+    title: String,
+    content: @Composable () -> Unit
+) {
+    Column {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        Card(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(
+                modifier = Modifier.padding(vertical = 8.dp)
+            ) {
+                content()
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SettingsItem(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit = {},
+    trailing: @Composable (() -> Unit)? = null
+) {
+    Surface(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp)
+            )
+            
+            Spacer(modifier = Modifier.width(16.dp))
+            
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline
+                )
+            }
+            
+            trailing?.invoke()
+        }
+    }
+}

--- a/app/src/main/java/com/fleetmanager/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/settings/SettingsScreen.kt
@@ -4,15 +4,12 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
-import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.fleetmanager.ui.components.*
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel()
@@ -26,11 +23,7 @@ fun SettingsScreen(
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         item {
-            Text(
-                text = "Settings",
-                style = MaterialTheme.typography.headlineMedium,
-                fontWeight = FontWeight.Bold
-            )
+            ScreenHeader(title = "Settings")
         }
 
         // Account Section
@@ -55,16 +48,12 @@ fun SettingsScreen(
         // Data & Sync Section
         item {
             SettingsSection(title = "Data & Sync") {
-                SettingsItem(
+                SettingsToggleItem(
                     icon = Icons.Default.Sync,
                     title = "Auto Sync",
                     subtitle = if (uiState.autoSyncEnabled) "Enabled" else "Disabled",
-                    trailing = {
-                        Switch(
-                            checked = uiState.autoSyncEnabled,
-                            onCheckedChange = { viewModel.toggleAutoSync(it) }
-                        )
-                    }
+                    checked = uiState.autoSyncEnabled,
+                    onCheckedChange = { viewModel.toggleAutoSync(it) }
                 )
                 
                 SettingsItem(
@@ -86,28 +75,20 @@ fun SettingsScreen(
         // Notifications Section
         item {
             SettingsSection(title = "Notifications") {
-                SettingsItem(
+                SettingsToggleItem(
                     icon = Icons.Default.Notifications,
                     title = "Push Notifications",
                     subtitle = if (uiState.notificationsEnabled) "Enabled" else "Disabled",
-                    trailing = {
-                        Switch(
-                            checked = uiState.notificationsEnabled,
-                            onCheckedChange = { viewModel.toggleNotifications(it) }
-                        )
-                    }
+                    checked = uiState.notificationsEnabled,
+                    onCheckedChange = { viewModel.toggleNotifications(it) }
                 )
                 
-                SettingsItem(
+                SettingsToggleItem(
                     icon = Icons.Default.Schedule,
                     title = "Daily Reminders",
                     subtitle = if (uiState.dailyRemindersEnabled) "Enabled" else "Disabled",
-                    trailing = {
-                        Switch(
-                            checked = uiState.dailyRemindersEnabled,
-                            onCheckedChange = { viewModel.toggleDailyReminders(it) }
-                        )
-                    }
+                    checked = uiState.dailyRemindersEnabled,
+                    onCheckedChange = { viewModel.toggleDailyReminders(it) }
                 )
             }
         }
@@ -167,132 +148,21 @@ fun SettingsScreen(
         // Show sync status if syncing
         if (uiState.isSyncing) {
             item {
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.primaryContainer
-                    )
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(24.dp),
-                            strokeWidth = 2.dp
-                        )
-                        Spacer(modifier = Modifier.width(16.dp))
-                        Text(
-                            text = "Syncing data...",
-                            style = MaterialTheme.typography.bodyMedium
-                        )
-                    }
-                }
+                StatusCard(
+                    type = StatusType.Loading,
+                    message = "Syncing data..."
+                )
             }
         }
 
         // Show error if any
         uiState.error?.let { error ->
             item {
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.errorContainer
-                    )
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Error,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onErrorContainer
-                        )
-                        Spacer(modifier = Modifier.width(16.dp))
-                        Text(
-                            text = error,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onErrorContainer
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun SettingsSection(
-    title: String,
-    content: @Composable () -> Unit
-) {
-    Column {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
-        Card(
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Column(
-                modifier = Modifier.padding(vertical = 8.dp)
-            ) {
-                content()
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun SettingsItem(
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
-    title: String,
-    subtitle: String,
-    onClick: () -> Unit = {},
-    trailing: @Composable (() -> Unit)? = null
-) {
-    Surface(
-        onClick = onClick,
-        modifier = Modifier.fillMaxWidth()
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(24.dp)
-            )
-            
-            Spacer(modifier = Modifier.width(16.dp))
-            
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium
-                )
-                Text(
-                    text = subtitle,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.outline
+                StatusCard(
+                    type = StatusType.Error,
+                    message = error
                 )
             }
-            
-            trailing?.invoke()
         }
     }
 }

--- a/app/src/main/java/com/fleetmanager/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/settings/SettingsViewModel.kt
@@ -1,0 +1,120 @@
+package com.fleetmanager.ui.screens.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.fleetmanager.auth.AuthService
+import com.fleetmanager.sync.SyncManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class SettingsUiState(
+    val autoSyncEnabled: Boolean = true,
+    val notificationsEnabled: Boolean = true,
+    val dailyRemindersEnabled: Boolean = true,
+    val selectedTheme: String = "System",
+    val appVersion: String = "1.1.0",
+    val lastSyncTime: String = "Never",
+    val isSyncing: Boolean = false,
+    val error: String? = null
+)
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val authService: AuthService,
+    private val syncManager: SyncManager
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SettingsUiState())
+    val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+
+    init {
+        loadSettings()
+    }
+
+    private fun loadSettings() {
+        viewModelScope.launch {
+            // TODO: Load settings from preferences
+            // For now, using default values
+            _uiState.value = _uiState.value.copy(
+                lastSyncTime = getLastSyncTime()
+            )
+        }
+    }
+
+    fun toggleAutoSync(enabled: Boolean) {
+        _uiState.value = _uiState.value.copy(autoSyncEnabled = enabled)
+        // TODO: Save to preferences
+        if (enabled) {
+            syncManager.startPeriodicSync()
+        } else {
+            syncManager.stopPeriodicSync()
+        }
+    }
+
+    fun toggleNotifications(enabled: Boolean) {
+        _uiState.value = _uiState.value.copy(notificationsEnabled = enabled)
+        // TODO: Save to preferences and update notification settings
+    }
+
+    fun toggleDailyReminders(enabled: Boolean) {
+        _uiState.value = _uiState.value.copy(dailyRemindersEnabled = enabled)
+        // TODO: Save to preferences and schedule/cancel daily reminders
+    }
+
+    fun syncNow() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isSyncing = true, error = null)
+            
+            try {
+                syncManager.syncNow()
+                _uiState.value = _uiState.value.copy(
+                    isSyncing = false,
+                    lastSyncTime = getCurrentTime()
+                )
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    isSyncing = false,
+                    error = "Sync failed: ${e.message}"
+                )
+            }
+        }
+    }
+
+    fun exportData() {
+        viewModelScope.launch {
+            try {
+                // TODO: Implement data export functionality
+                _uiState.value = _uiState.value.copy(error = "Export feature coming soon!")
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    error = "Export failed: ${e.message}"
+                )
+            }
+        }
+    }
+
+    fun signOut() {
+        viewModelScope.launch {
+            try {
+                authService.signOut()
+                // Navigation will be handled by the auth state observer in MainActivity
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    error = "Sign out failed: ${e.message}"
+                )
+            }
+        }
+    }
+
+    private fun getLastSyncTime(): String {
+        // TODO: Get actual last sync time from preferences
+        return "Just now"
+    }
+
+    private fun getCurrentTime(): String {
+        return java.text.SimpleDateFormat("MMM dd, HH:mm", java.util.Locale.getDefault())
+            .format(java.util.Date())
+    }
+}


### PR DESCRIPTION
Optimized GitHub Actions workflow to significantly reduce build times and added a Jetpack Compose bottom navigation bar with Dashboard, History, and Settings screens.

The previous GitHub Actions workflow suffered from prolonged post-job durations (up to 40 minutes) due to inefficient caching, redundant steps, and unoptimized artifact handling. This PR introduces a timeout, leverages built-in Gradle caching, streamlines artifact uploads, and adds PR support to bring build times down to an estimated 5-8 minutes.

---
<a href="https://cursor.com/background-agent?bcId=bc-b37b1600-5869-4175-9c74-cbf445bbe44c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b37b1600-5869-4175-9c74-cbf445bbe44c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

