### PR TITLE
Fix kotlin compilation overload ambiguity

### DIFF
--- a/app/src/main/java/com/fleetmanager/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/dashboard/DashboardScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.fleetmanager.ui.components.*
 import com.fleetmanager.ui.utils.collectAsStateWithLifecycle
-import com.fleetmanager.ui.utils.rememberStableLambda
+import com.fleetmanager.ui.utils.rememberStableLambda0
 import com.fleetmanager.ui.viewmodel.DashboardViewModel
 
 @Composable
@@ -25,8 +25,8 @@ fun DashboardScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     
     // Create stable lambdas to prevent unnecessary recompositions
-    val onAddClick: () -> Unit = rememberStableLambda { onAddEntryClick() }
-    val onSyncClick: () -> Unit = rememberStableLambda { viewModel.syncNow() }
+    val onAddClick: () -> Unit = rememberStableLambda0({ onAddEntryClick() })
+    val onSyncClick: () -> Unit = rememberStableLambda0({ viewModel.syncNow() })
 
     LazyColumn(
         modifier = Modifier

--- a/app/src/main/java/com/fleetmanager/ui/screens/entry/EntryListScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/entry/EntryListScreen.kt
@@ -17,7 +17,8 @@ import com.fleetmanager.ui.viewmodel.EntryListViewModel
 import com.fleetmanager.domain.model.DailyEntry
 import com.fleetmanager.ui.components.*
 import com.fleetmanager.ui.utils.collectAsStateWithLifecycle
-import com.fleetmanager.ui.utils.rememberStableLambda
+import com.fleetmanager.ui.utils.rememberStableLambda0
+import com.fleetmanager.ui.utils.rememberStableLambda1
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -30,8 +31,8 @@ fun EntryListScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     
     // Create stable lambdas to prevent unnecessary recompositions
-    val onAddClick: () -> Unit = rememberStableLambda { onAddEntryClick() }
-    val onItemClick: (String) -> Unit = rememberStableLambda { entryId: String -> onEntryClick(entryId) }
+    val onAddClick: () -> Unit = rememberStableLambda0({ onAddEntryClick() })
+    val onItemClick: (String) -> Unit = rememberStableLambda1({ entryId: String -> onEntryClick(entryId) })
     
     LazyColumn(
         modifier = Modifier

--- a/app/src/main/java/com/fleetmanager/ui/utils/ComposeUtils.kt
+++ b/app/src/main/java/com/fleetmanager/ui/utils/ComposeUtils.kt
@@ -44,7 +44,7 @@ fun <T> Flow<T>.collectAsStateWithLifecycle(
  * Creates a stable lambda that won't cause recompositions.
  */
 @Composable
-fun <T> rememberStableLambda(key: Any? = null, lambda: () -> T): () -> T {
+fun <T> rememberStableLambda0(lambda: () -> T, key: Any? = null): () -> T {
     return remember(key) { lambda }
 }
 
@@ -52,7 +52,7 @@ fun <T> rememberStableLambda(key: Any? = null, lambda: () -> T): () -> T {
  * Creates a stable lambda with one parameter that won't cause recompositions.
  */
 @Composable
-fun <P, T> rememberStableLambda(key: Any? = null, lambda: (P) -> T): (P) -> T {
+fun <P, T> rememberStableLambda1(lambda: (P) -> T, key: Any? = null): (P) -> T {
     return remember(key) { lambda }
 }
 


### PR DESCRIPTION
Rename `rememberStableLambda` functions to resolve Kotlin compilation overload ambiguity.

---
<a href="https://cursor.com/background-agent?bcId=bc-0705ef1a-dc05-4568-9e96-beba7157ee27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0705ef1a-dc05-4568-9e96-beba7157ee27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

