### PR TITLE
Fix floating action button navigation to screens

### DIFF
--- a/app/src/main/java/com/fleetmanager/ui/components/FloatingActionButtonMenu.kt
+++ b/app/src/main/java/com/fleetmanager/ui/components/FloatingActionButtonMenu.kt
@@ -57,6 +57,15 @@ fun FloatingActionButtonMenu(
         modifier = modifier,
         contentAlignment = Alignment.BottomEnd
     ) {
+        // Invisible overlay to close menu when tapping outside
+        if (isExpanded) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clickable { isExpanded = false }
+            )
+        }
+        
         // Menu items
         AnimatedVisibility(
             visible = isExpanded,
@@ -91,15 +100,6 @@ fun FloatingActionButtonMenu(
                 imageVector = fabIcon,
                 contentDescription = if (isExpanded) "Close menu" else "Open menu",
                 modifier = Modifier.rotate(rotationAngle)
-            )
-        }
-        
-        // Invisible overlay to close menu when tapping outside
-        if (isExpanded) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .clickable { isExpanded = false }
             )
         }
     }

--- a/app/src/main/java/com/fleetmanager/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/dashboard/DashboardScreen.kt
@@ -29,7 +29,7 @@ fun DashboardScreen(
     
     // Create stable lambdas to prevent unnecessary recompositions
     val onAddClick: () -> Unit = rememberStableLambda0({ onAddEntryClick() })
-    val onAddExpenseClick: () -> Unit = rememberStableLambda0({ onAddExpenseClick() })
+    val onExpenseClick: () -> Unit = rememberStableLambda0({ onAddExpenseClick() })
     val onSyncClick: () -> Unit = rememberStableLambda0({ viewModel.syncNow() })
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -106,7 +106,7 @@ fun DashboardScreen(
         FloatingActionButtonMenu(
             items = createDefaultFabMenuItems(
                 onIncomeClick = onAddClick,
-                onExpenseClick = onAddExpenseClick
+                onExpenseClick = onExpenseClick
             ),
             modifier = Modifier
                 .align(Alignment.BottomEnd)

--- a/app/src/main/java/com/fleetmanager/ui/screens/entry/EntryListScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/entry/EntryListScreen.kt
@@ -33,7 +33,7 @@ fun EntryListScreen(
     
     // Create stable lambdas to prevent unnecessary recompositions
     val onAddClick: () -> Unit = rememberStableLambda0({ onAddEntryClick() })
-    val onAddExpenseClick: () -> Unit = rememberStableLambda0({ onAddExpenseClick() })
+    val onExpenseClick: () -> Unit = rememberStableLambda0({ onAddExpenseClick() })
     val onItemClick: (String) -> Unit = rememberStableLambda1({ entryId: String -> onEntryClick(entryId) })
     
     Box(modifier = Modifier.fillMaxSize()) {
@@ -87,7 +87,7 @@ fun EntryListScreen(
         FloatingActionButtonMenu(
             items = createDefaultFabMenuItems(
                 onIncomeClick = onAddClick,
-                onExpenseClick = onAddExpenseClick
+                onExpenseClick = onExpenseClick
             ),
             modifier = Modifier
                 .align(Alignment.BottomEnd)


### PR DESCRIPTION
Fix floating action button navigation by resolving a lambda variable name collision and repositioning the menu overlay.

The `onAddExpenseClick` lambda in `DashboardScreen` and `EntryListScreen` was recursively calling itself due to a variable name conflict, preventing navigation. Additionally, an invisible overlay in `FloatingActionButtonMenu` was intercepting clicks on the menu items. These changes ensure that clicking "Income" navigates to `AddEntryScreen` and "Expense" navigates to `NewExpenseEntryScreen`.

---
<a href="https://cursor.com/background-agent?bcId=bc-811284d1-4688-4835-b344-2c5aa48244b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-811284d1-4688-4835-b344-2c5aa48244b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

