### PR TITLE
Revert to sign-in screen as landing page

### DIFF
--- a/app/src/main/java/com/fleetmanager/MainActivity.kt
+++ b/app/src/main/java/com/fleetmanager/MainActivity.kt
@@ -4,14 +4,19 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.*
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.rememberNavController
-import com.fleetmanager.ui.navigation.MainScreenWithBottomNav
-import com.fleetmanager.ui.navigation.Screen
+import com.fleetmanager.auth.AuthService
+import com.fleetmanager.ui.navigation.AppNavigation
 import com.fleetmanager.ui.theme.FleetManagerTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    
+    @Inject
+    lateinit var authService: AuthService
     
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -19,9 +24,11 @@ class MainActivity : ComponentActivity() {
         setContent {
             FleetManagerTheme {
                 val navController = rememberNavController()
+                val isSignedIn by authService.isSignedIn.collectAsState(initial = false)
                 
-                MainScreenWithBottomNav(
-                    navController = navController
+                AppNavigation(
+                    navController = navController,
+                    isSignedIn = isSignedIn
                 )
             }
         }

--- a/app/src/main/java/com/fleetmanager/ui/navigation/FleetNavigation.kt
+++ b/app/src/main/java/com/fleetmanager/ui/navigation/FleetNavigation.kt
@@ -56,6 +56,23 @@ val bottomNavItems = listOf(
 
 
 @Composable
+fun AppNavigation(
+    navController: NavHostController,
+    isSignedIn: Boolean
+) {
+    if (isSignedIn) {
+        MainScreenWithBottomNav(navController = navController)
+    } else {
+        // Show only the sign-in screen when not authenticated
+        FleetNavigation(
+            navController = navController,
+            startDestination = Screen.SignIn.route,
+            modifier = Modifier
+        )
+    }
+}
+
+@Composable
 fun MainScreenWithBottomNav(
     navController: NavHostController
 ) {


### PR DESCRIPTION
Restore the SignIn screen as the app's landing page to require user authentication at startup.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6ee7eb2-384f-468d-a4d7-991c0ecd059d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f6ee7eb2-384f-468d-a4d7-991c0ecd059d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

