### PR TITLE
Fix photo upload and form dropdowns

### DIFF
--- a/app/src/main/java/com/fleetmanager/ui/screens/entry/AddEntryScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/entry/AddEntryScreen.kt
@@ -41,12 +41,6 @@ fun AddEntryScreen(
     val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current
     
-    val photoPickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.PickVisualMedia()
-    ) { uri ->
-        uri?.let { viewModel.updatePhotoUri(it) }
-    }
-    
     val multiplePhotoPickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickMultipleVisualMedia(maxItems = 5)
     ) { uris ->
@@ -289,32 +283,16 @@ fun AddEntryScreen(
                         }
                     }
                     
-                    // Photo selection buttons
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    // Photo selection button
+                    OutlinedButton(
+                        onClick = {
+                            multiplePhotoPickerLauncher.launch(
+                                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                            )
+                        },
+                        modifier = Modifier.fillMaxWidth()
                     ) {
-                        OutlinedButton(
-                            onClick = {
-                                photoPickerLauncher.launch(
-                                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
-                                )
-                            },
-                            modifier = Modifier.weight(1f)
-                        ) {
-                            Text("Add Photo")
-                        }
-                        
-                        OutlinedButton(
-                            onClick = {
-                                multiplePhotoPickerLauncher.launch(
-                                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
-                                )
-                            },
-                            modifier = Modifier.weight(1f)
-                        ) {
-                            Text("Add Multiple")
-                        }
+                        Text("Add Photos")
                     }
                 }
             }

--- a/app/src/main/java/com/fleetmanager/ui/screens/entry/NewExpenseEntryScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/entry/NewExpenseEntryScreen.kt
@@ -40,12 +40,6 @@ fun NewExpenseEntryScreen(
     val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current
     
-    val photoPickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.PickVisualMedia()
-    ) { uri ->
-        uri?.let { viewModel.updatePhotoUri(it) }
-    }
-    
     val multiplePhotoPickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickMultipleVisualMedia(maxItems = 5)
     ) { uris ->
@@ -171,9 +165,9 @@ fun NewExpenseEntryScreen(
                 onExpandedChange = viewModel::toggleDriverDropdown
             ) {
                 OutlinedTextField(
-                    value = uiState.selectedDriver?.name ?: "",
-                    onValueChange = { },
-                    readOnly = true,
+                    value = uiState.driverInput,
+                    onValueChange = viewModel::updateDriverInput,
+                    readOnly = false,
                     label = { Text("Driver") },
                     trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = uiState.driverDropdownExpanded) },
                     modifier = Modifier
@@ -203,9 +197,9 @@ fun NewExpenseEntryScreen(
                 onExpandedChange = viewModel::toggleVehicleDropdown
             ) {
                 OutlinedTextField(
-                    value = uiState.selectedVehicle?.displayName ?: "",
-                    onValueChange = { },
-                    readOnly = true,
+                    value = uiState.vehicleInput,
+                    onValueChange = viewModel::updateVehicleInput,
+                    readOnly = false,
                     label = { Text("Vehicle") },
                     trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = uiState.vehicleDropdownExpanded) },
                     modifier = Modifier
@@ -308,32 +302,16 @@ fun NewExpenseEntryScreen(
                         }
                     }
                     
-                    // Photo selection buttons
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    // Photo selection button
+                    OutlinedButton(
+                        onClick = {
+                            multiplePhotoPickerLauncher.launch(
+                                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                            )
+                        },
+                        modifier = Modifier.fillMaxWidth()
                     ) {
-                        OutlinedButton(
-                            onClick = {
-                                photoPickerLauncher.launch(
-                                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
-                                )
-                            },
-                            modifier = Modifier.weight(1f)
-                        ) {
-                            Text("Add Photo")
-                        }
-                        
-                        OutlinedButton(
-                            onClick = {
-                                multiplePhotoPickerLauncher.launch(
-                                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
-                                )
-                            },
-                            modifier = Modifier.weight(1f)
-                        ) {
-                            Text("Add Multiple")
-                        }
+                        Text("Add Photos")
                     }
                 }
             }


### PR DESCRIPTION
Consolidate photo upload buttons and fix expense form dropdowns to use a consistent data source and allow manual entry.

The expense form's car and driver dropdowns were not working and used different sample data than the income form. This PR unifies the data source for both forms, populating the dropdowns with specified sample data, and enables manual input, mirroring the income form's behavior. The redundant "Add Photo" button was removed, leaving a single "Add Photos" button that supports multiple selections.

---
<a href="https://cursor.com/background-agent?bcId=bc-63f5dd0f-dd55-4620-9816-8d1af6da609f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-63f5dd0f-dd55-4620-9816-8d1af6da609f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

