### PR TITLE
Add firestore save error toasts

### DIFF
--- a/app/src/main/java/com/fleetmanager/data/remote/FirestoreService.kt
+++ b/app/src/main/java/com/fleetmanager/data/remote/FirestoreService.kt
@@ -1,5 +1,6 @@
 package com.fleetmanager.data.remote
 
+import android.content.Context
 import android.util.Log
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ktx.snapshots
@@ -9,6 +10,8 @@ import com.fleetmanager.domain.model.DailyEntry
 import com.fleetmanager.domain.model.Driver
 import com.fleetmanager.domain.model.Vehicle
 import com.fleetmanager.domain.model.Expense
+import com.fleetmanager.ui.utils.ToastHelper
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.tasks.await
@@ -18,7 +21,9 @@ import javax.inject.Singleton
 @Singleton
 class FirestoreService @Inject constructor(
     private val firestore: FirebaseFirestore,
-    private val authService: AuthService
+    private val authService: AuthService,
+    @ApplicationContext private val context: Context,
+    private val toastHelper: ToastHelper
 ) {
     
     companion object {
@@ -44,11 +49,18 @@ class FirestoreService @Inject constructor(
     suspend fun saveDailyEntry(entry: DailyEntry) {
         val userId = requireAuth()
         Log.d(TAG, "Saving daily entry to Firestore for user $userId: ${entry.id}")
-        getUserCollection("dailyEntries")
-            .document(entry.id)
-            .set(entry)
-            .await()
-        Log.d(TAG, "Successfully saved daily entry to Firestore: ${entry.id}")
+        try {
+            getUserCollection("dailyEntries")
+                .document(entry.id)
+                .set(entry)
+                .await()
+            Log.d(TAG, "Successfully saved daily entry to Firestore: ${entry.id}")
+        } catch (e: Exception) {
+            val errorMessage = "Failed to save daily entry: ${e.message}"
+            Log.e(TAG, errorMessage, e)
+            toastHelper.showError(context, errorMessage)
+            throw e
+        }
     }
     
     suspend fun getDailyEntries(): List<DailyEntry> {
@@ -76,10 +88,18 @@ class FirestoreService @Inject constructor(
     
     // Drivers
     suspend fun saveDriver(driver: Driver) {
-        getUserCollection("drivers")
-            .document(driver.id)
-            .set(driver)
-            .await()
+        try {
+            getUserCollection("drivers")
+                .document(driver.id)
+                .set(driver)
+                .await()
+            Log.d(TAG, "Successfully saved driver to Firestore: ${driver.id}")
+        } catch (e: Exception) {
+            val errorMessage = "Failed to save driver: ${e.message}"
+            Log.e(TAG, errorMessage, e)
+            toastHelper.showError(context, errorMessage)
+            throw e
+        }
     }
     
     suspend fun getDrivers(): List<Driver> {
@@ -92,10 +112,18 @@ class FirestoreService @Inject constructor(
     
     // Vehicles
     suspend fun saveVehicle(vehicle: Vehicle) {
-        getUserCollection("vehicles")
-            .document(vehicle.id)
-            .set(vehicle)
-            .await()
+        try {
+            getUserCollection("vehicles")
+                .document(vehicle.id)
+                .set(vehicle)
+                .await()
+            Log.d(TAG, "Successfully saved vehicle to Firestore: ${vehicle.id}")
+        } catch (e: Exception) {
+            val errorMessage = "Failed to save vehicle: ${e.message}"
+            Log.e(TAG, errorMessage, e)
+            toastHelper.showError(context, errorMessage)
+            throw e
+        }
     }
     
     suspend fun getVehicles(): List<Vehicle> {
@@ -178,11 +206,18 @@ class FirestoreService @Inject constructor(
     suspend fun saveExpense(expense: Expense) {
         val userId = requireAuth()
         Log.d(TAG, "Saving expense to Firestore for user $userId: ${expense.id}")
-        getUserCollection("expenses")
-            .document(expense.id)
-            .set(expense)
-            .await()
-        Log.d(TAG, "Successfully saved expense to Firestore: ${expense.id}")
+        try {
+            getUserCollection("expenses")
+                .document(expense.id)
+                .set(expense)
+                .await()
+            Log.d(TAG, "Successfully saved expense to Firestore: ${expense.id}")
+        } catch (e: Exception) {
+            val errorMessage = "Failed to save expense: ${e.message}"
+            Log.e(TAG, errorMessage, e)
+            toastHelper.showError(context, errorMessage)
+            throw e
+        }
     }
     
     suspend fun getExpenses(): List<Expense> {

--- a/app/src/main/java/com/fleetmanager/data/remote/StorageService.kt
+++ b/app/src/main/java/com/fleetmanager/data/remote/StorageService.kt
@@ -1,8 +1,12 @@
 package com.fleetmanager.data.remote
 
+import android.content.Context
 import android.net.Uri
+import android.util.Log
 import com.google.firebase.storage.FirebaseStorage
 import com.fleetmanager.auth.AuthService
+import com.fleetmanager.ui.utils.ToastHelper
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.tasks.await
 import java.util.UUID
 import javax.inject.Inject
@@ -11,8 +15,14 @@ import javax.inject.Singleton
 @Singleton
 class StorageService @Inject constructor(
     private val storage: FirebaseStorage,
-    private val authService: AuthService
+    private val authService: AuthService,
+    @ApplicationContext private val context: Context,
+    private val toastHelper: ToastHelper
 ) {
+    
+    companion object {
+        private const val TAG = "StorageService"
+    }
     
     private fun getUserStorage() = 
         storage.reference
@@ -24,15 +34,28 @@ class StorageService @Inject constructor(
         val fileName = "${entryId}_${UUID.randomUUID()}.jpg"
         val photoRef = getUserStorage().child(fileName)
         
-        photoRef.putFile(uri).await()
-        return photoRef.downloadUrl.await().toString()
+        return try {
+            photoRef.putFile(uri).await()
+            val downloadUrl = photoRef.downloadUrl.await().toString()
+            Log.d(TAG, "Successfully uploaded photo: $fileName")
+            downloadUrl
+        } catch (e: Exception) {
+            val errorMessage = "Failed to upload photo: ${e.message}"
+            Log.e(TAG, errorMessage, e)
+            toastHelper.showError(context, errorMessage)
+            throw e
+        }
     }
     
     suspend fun deletePhoto(photoUrl: String) {
         try {
             storage.getReferenceFromUrl(photoUrl).delete().await()
+            Log.d(TAG, "Successfully deleted photo: $photoUrl")
         } catch (e: Exception) {
-            // Photo might not exist, ignore error
+            val errorMessage = "Failed to delete photo: ${e.message}"
+            Log.e(TAG, errorMessage, e)
+            toastHelper.showError(context, errorMessage)
+            // Photo might not exist, don't rethrow the exception
         }
     }
 }

--- a/app/src/main/java/com/fleetmanager/data/repository/FleetRepositoryImpl.kt
+++ b/app/src/main/java/com/fleetmanager/data/repository/FleetRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.fleetmanager.data.repository
 
+import android.content.Context
 import android.net.Uri
 import android.util.Log
 import com.fleetmanager.data.local.dao.DailyEntryDao
@@ -17,6 +18,8 @@ import com.fleetmanager.domain.model.Driver
 import com.fleetmanager.domain.model.Vehicle
 import com.fleetmanager.domain.model.Expense
 import com.fleetmanager.domain.repository.FleetRepository
+import com.fleetmanager.ui.utils.ToastHelper
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -31,7 +34,9 @@ class FleetRepositoryImpl @Inject constructor(
     private val vehicleDao: VehicleDao,
     private val expenseDao: ExpenseDao,
     private val firestoreService: FirestoreService,
-    private val storageService: StorageService
+    private val storageService: StorageService,
+    @ApplicationContext private val context: Context,
+    private val toastHelper: ToastHelper
 ) : FleetRepository {
     
     companion object {
@@ -86,7 +91,9 @@ class FleetRepositoryImpl @Inject constructor(
                 dailyEntryDao.markAsSynced(entryToSave.id)
                 Log.d(TAG, "Successfully saved daily entry to Firestore: ${entryToSave.id}")
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to save daily entry to Firestore: ${entryToSave.id}", e)
+                val errorMessage = "Failed to save daily entry to Firestore: ${e.message}"
+                Log.e(TAG, errorMessage, e)
+                toastHelper.showError(context, errorMessage)
                 // Will be synced later by WorkManager
             }
         }
@@ -114,6 +121,9 @@ class FleetRepositoryImpl @Inject constructor(
                 firestoreService.saveDailyEntry(syncedEntry)
                 dailyEntryDao.updateEntry(DailyEntryMapper.toDto(syncedEntry))
             } catch (e: Exception) {
+                val errorMessage = "Failed to sync daily entry ${entryDto.id}: ${e.message}"
+                Log.e(TAG, errorMessage, e)
+                toastHelper.showError(context, errorMessage)
                 // Keep as unsynced for next attempt
             }
         }
@@ -144,6 +154,9 @@ class FleetRepositoryImpl @Inject constructor(
         try {
             firestoreService.saveDriver(driver)
         } catch (e: Exception) {
+            val errorMessage = "Failed to save driver to Firestore: ${e.message}"
+            Log.e(TAG, errorMessage, e)
+            toastHelper.showError(context, errorMessage)
             // Will be synced later
         }
     }
@@ -166,6 +179,9 @@ class FleetRepositoryImpl @Inject constructor(
         try {
             firestoreService.saveVehicle(vehicle)
         } catch (e: Exception) {
+            val errorMessage = "Failed to save vehicle to Firestore: ${e.message}"
+            Log.e(TAG, errorMessage, e)
+            toastHelper.showError(context, errorMessage)
             // Will be synced later
         }
     }
@@ -227,7 +243,9 @@ class FleetRepositoryImpl @Inject constructor(
                 expenseDao.markAsSynced(expenseToSave.id)
                 Log.d(TAG, "Successfully saved expense to Firestore: ${expenseToSave.id}")
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to save expense to Firestore: ${expenseToSave.id}", e)
+                val errorMessage = "Failed to save expense to Firestore: ${e.message}"
+                Log.e(TAG, errorMessage, e)
+                toastHelper.showError(context, errorMessage)
                 // Will be synced later by WorkManager
             }
         }
@@ -259,6 +277,9 @@ class FleetRepositoryImpl @Inject constructor(
                 firestoreService.saveExpense(syncedExpense)
                 expenseDao.updateExpense(ExpenseMapper.toDto(syncedExpense))
             } catch (e: Exception) {
+                val errorMessage = "Failed to sync expense ${expenseDto.id}: ${e.message}"
+                Log.e(TAG, errorMessage, e)
+                toastHelper.showError(context, errorMessage)
                 // Keep as unsynced for next attempt
             }
         }

--- a/app/src/main/java/com/fleetmanager/di/FirebaseModule.kt
+++ b/app/src/main/java/com/fleetmanager/di/FirebaseModule.kt
@@ -3,6 +3,7 @@ package com.fleetmanager.di
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.storage.FirebaseStorage
+import com.fleetmanager.ui.utils.ToastHelper
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -24,4 +25,8 @@ object FirebaseModule {
     @Provides
     @Singleton
     fun provideFirebaseStorage(): FirebaseStorage = FirebaseStorage.getInstance()
+    
+    @Provides
+    @Singleton
+    fun provideToastHelper(): ToastHelper = ToastHelper()
 }

--- a/app/src/main/java/com/fleetmanager/ui/utils/ToastHelper.kt
+++ b/app/src/main/java/com/fleetmanager/ui/utils/ToastHelper.kt
@@ -1,0 +1,62 @@
+package com.fleetmanager.ui.utils
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.widget.Toast
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Helper class to show Toast messages from any layer of the application.
+ * This is particularly useful for debugging Firestore errors when logs are not accessible.
+ */
+@Singleton
+class ToastHelper @Inject constructor() {
+    
+    companion object {
+        @Volatile
+        private var INSTANCE: ToastHelper? = null
+        
+        fun getInstance(): ToastHelper {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: ToastHelper().also { INSTANCE = it }
+            }
+        }
+    }
+    
+    /**
+     * Show a Toast message from any thread.
+     * This method ensures the Toast is shown on the UI thread.
+     */
+    fun showError(context: Context?, message: String) {
+        context?.let { ctx ->
+            if (Looper.myLooper() == Looper.getMainLooper()) {
+                // Already on UI thread
+                Toast.makeText(ctx, "Error: $message", Toast.LENGTH_LONG).show()
+            } else {
+                // Post to UI thread
+                Handler(Looper.getMainLooper()).post {
+                    Toast.makeText(ctx, "Error: $message", Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+    }
+    
+    /**
+     * Show a general Toast message from any thread.
+     */
+    fun showMessage(context: Context?, message: String) {
+        context?.let { ctx ->
+            if (Looper.myLooper() == Looper.getMainLooper()) {
+                // Already on UI thread
+                Toast.makeText(ctx, message, Toast.LENGTH_LONG).show()
+            } else {
+                // Post to UI thread
+                Handler(Looper.getMainLooper()).post {
+                    Toast.makeText(ctx, message, Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add Toast error messages to all Firestore and Firebase Storage operations for temporary on-device debugging without Logcat.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed0f168b-7a55-4190-a33e-5907662623af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ed0f168b-7a55-4190-a33e-5907662623af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

