### PR TITLE
Fix permissions and dynamic report filters

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,10 +25,13 @@ android {
 
     signingConfigs {
         create("externalOverride") {
-            storeFile = file(System.getenv("KEYSTORE_PATH"))
-            storePassword = System.getenv("KEYSTORE_PASSWORD")
-            keyAlias = System.getenv("KEY_ALIAS")
-            keyPassword = System.getenv("KEY_PASSWORD")
+            val keystorePath = System.getenv("KEYSTORE_PATH")
+            if (keystorePath != null) {
+                storeFile = file(keystorePath)
+                storePassword = System.getenv("KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("KEY_ALIAS")
+                keyPassword = System.getenv("KEY_PASSWORD")
+            }
         }
     }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -24,6 +24,14 @@
 -keep class com.google.firebase.** { *; }
 -keep class com.google.android.gms.** { *; }
 
+# Keep Firestore model classes and their constructors
+-keep class com.fleetmanager.domain.model.** { *; }
+-keep class com.fleetmanager.data.dto.** { *; }
+-keepclassmembers class com.fleetmanager.domain.model.** {
+    <init>();
+    <init>(...);
+}
+
 # Keep Hilt generated classes
 -keep class dagger.hilt.** { *; }
 -keep class javax.inject.** { *; }

--- a/app/src/main/java/com/fleetmanager/data/remote/ExpenseTypeFirestoreService.kt
+++ b/app/src/main/java/com/fleetmanager/data/remote/ExpenseTypeFirestoreService.kt
@@ -1,0 +1,131 @@
+package com.fleetmanager.data.remote
+
+import android.content.Context
+import android.util.Log
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.snapshots
+import com.google.firebase.firestore.ktx.toObject
+import com.fleetmanager.domain.model.ExpenseTypeItem
+import com.fleetmanager.ui.utils.ToastHelper
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ExpenseTypeFirestoreService @Inject constructor(
+    private val firestore: FirebaseFirestore,
+    @ApplicationContext private val context: Context,
+    private val toastHelper: ToastHelper
+) {
+    
+    companion object {
+        private const val TAG = "ExpenseTypeFirestoreService"
+        private const val EXPENSE_TYPES_COLLECTION = "expenseTypes"
+    }
+    
+    private fun getCollection() = firestore.collection(EXPENSE_TYPES_COLLECTION)
+    
+    suspend fun saveExpenseType(expenseType: ExpenseTypeItem) {
+        try {
+            getCollection()
+                .document(expenseType.id)
+                .set(expenseType)
+                .await()
+            Log.d(TAG, "Successfully saved expense type: ${expenseType.id}")
+        } catch (e: Exception) {
+            val errorMessage = "Failed to save expense type: ${e.message}"
+            Log.e(TAG, errorMessage, e)
+            toastHelper.showError(context, errorMessage)
+            throw e
+        }
+    }
+    
+    suspend fun getExpenseTypes(): List<ExpenseTypeItem> {
+        return try {
+            getCollection()
+                .whereEqualTo("isActive", true)
+                .get()
+                .await()
+                .documents
+                .mapNotNull { it.toObject<ExpenseTypeItem>() }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to fetch expense types: ${e.message}", e)
+            emptyList()
+        }
+    }
+    
+    fun getExpenseTypesFlow(): Flow<List<ExpenseTypeItem>> {
+        return getCollection()
+            .whereEqualTo("isActive", true)
+            .snapshots()
+            .map { snapshot ->
+                snapshot.documents.mapNotNull { it.toObject<ExpenseTypeItem>() }
+            }
+    }
+    
+    suspend fun createExpenseType(name: String, displayName: String): ExpenseTypeItem {
+        val expenseTypeId = java.util.UUID.randomUUID().toString()
+        val expenseType = ExpenseTypeItem(
+            id = expenseTypeId,
+            name = name.uppercase().replace(" ", "_"),
+            displayName = displayName,
+            isActive = true
+        )
+        
+        saveExpenseType(expenseType)
+        return expenseType
+    }
+    
+    suspend fun initializeDefaultExpenseTypes() {
+        val existingExpenseTypes = getExpenseTypes()
+        if (existingExpenseTypes.isEmpty()) {
+            Log.d(TAG, "Initializing default expense types...")
+            val defaultExpenseTypes = listOf(
+                ExpenseTypeItem(
+                    id = "fuel",
+                    name = "FUEL",
+                    displayName = "Fuel",
+                    isActive = true
+                ),
+                ExpenseTypeItem(
+                    id = "maintenance",
+                    name = "MAINTENANCE",
+                    displayName = "Maintenance",
+                    isActive = true
+                ),
+                ExpenseTypeItem(
+                    id = "service",
+                    name = "SERVICE",
+                    displayName = "Service",
+                    isActive = true
+                ),
+                ExpenseTypeItem(
+                    id = "car_wash",
+                    name = "CAR_WASH",
+                    displayName = "Car Wash",
+                    isActive = true
+                ),
+                ExpenseTypeItem(
+                    id = "fine",
+                    name = "FINE",
+                    displayName = "Fine",
+                    isActive = true
+                ),
+                ExpenseTypeItem(
+                    id = "other",
+                    name = "OTHER",
+                    displayName = "Other",
+                    isActive = true
+                )
+            )
+            
+            defaultExpenseTypes.forEach { expenseType ->
+                saveExpenseType(expenseType)
+            }
+            Log.d(TAG, "✅ Default expense types initialized")
+        }
+    }
+}

--- a/app/src/main/java/com/fleetmanager/data/remote/ExpenseTypeFirestoreService.kt
+++ b/app/src/main/java/com/fleetmanager/data/remote/ExpenseTypeFirestoreService.kt
@@ -23,7 +23,7 @@ class ExpenseTypeFirestoreService @Inject constructor(
     
     companion object {
         private const val TAG = "ExpenseTypeFirestoreService"
-        private const val EXPENSE_TYPES_COLLECTION = "expenseTypes"
+        private const val EXPENSE_TYPES_COLLECTION = "expense_types"
     }
     
     private fun getCollection() = firestore.collection(EXPENSE_TYPES_COLLECTION)
@@ -46,7 +46,6 @@ class ExpenseTypeFirestoreService @Inject constructor(
     suspend fun getExpenseTypes(): List<ExpenseTypeItem> {
         return try {
             getCollection()
-                .whereEqualTo("isActive", true)
                 .get()
                 .await()
                 .documents
@@ -59,7 +58,6 @@ class ExpenseTypeFirestoreService @Inject constructor(
     
     fun getExpenseTypesFlow(): Flow<List<ExpenseTypeItem>> {
         return getCollection()
-            .whereEqualTo("isActive", true)
             .snapshots()
             .map { snapshot ->
                 snapshot.documents.mapNotNull { it.toObject<ExpenseTypeItem>() }
@@ -79,53 +77,4 @@ class ExpenseTypeFirestoreService @Inject constructor(
         return expenseType
     }
     
-    suspend fun initializeDefaultExpenseTypes() {
-        val existingExpenseTypes = getExpenseTypes()
-        if (existingExpenseTypes.isEmpty()) {
-            Log.d(TAG, "Initializing default expense types...")
-            val defaultExpenseTypes = listOf(
-                ExpenseTypeItem(
-                    id = "fuel",
-                    name = "FUEL",
-                    displayName = "Fuel",
-                    isActive = true
-                ),
-                ExpenseTypeItem(
-                    id = "maintenance",
-                    name = "MAINTENANCE",
-                    displayName = "Maintenance",
-                    isActive = true
-                ),
-                ExpenseTypeItem(
-                    id = "service",
-                    name = "SERVICE",
-                    displayName = "Service",
-                    isActive = true
-                ),
-                ExpenseTypeItem(
-                    id = "car_wash",
-                    name = "CAR_WASH",
-                    displayName = "Car Wash",
-                    isActive = true
-                ),
-                ExpenseTypeItem(
-                    id = "fine",
-                    name = "FINE",
-                    displayName = "Fine",
-                    isActive = true
-                ),
-                ExpenseTypeItem(
-                    id = "other",
-                    name = "OTHER",
-                    displayName = "Other",
-                    isActive = true
-                )
-            )
-            
-            defaultExpenseTypes.forEach { expenseType ->
-                saveExpenseType(expenseType)
-            }
-            Log.d(TAG, "✅ Default expense types initialized")
-        }
-    }
 }

--- a/app/src/main/java/com/fleetmanager/data/remote/UserFirestoreService.kt
+++ b/app/src/main/java/com/fleetmanager/data/remote/UserFirestoreService.kt
@@ -1,0 +1,189 @@
+package com.fleetmanager.data.remote
+
+import android.content.Context
+import android.util.Log
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.snapshots
+import com.fleetmanager.auth.AuthService
+import com.fleetmanager.data.dto.UserDto
+import com.fleetmanager.domain.model.UserRole
+import com.fleetmanager.ui.utils.ToastHelper
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UserFirestoreService @Inject constructor(
+    private val firestore: FirebaseFirestore,
+    private val authService: AuthService,
+    @ApplicationContext private val context: Context,
+    private val toastHelper: ToastHelper
+) {
+    
+    companion object {
+        private const val TAG = "UserFirestoreService"
+        private const val USERS_COLLECTION = "users"
+    }
+    
+    private fun getCollection() = firestore.collection(USERS_COLLECTION)
+    
+    // Get user profile from Firestore
+    fun getUserProfile(userId: String): Flow<UserDto> {
+        return getCollection()
+            .document(userId)
+            .snapshots()
+            .map { document ->
+                if (document.exists()) {
+                    UserDto(
+                        id = document.id,
+                        name = document.getString("displayName") ?: document.getString("name") ?: "Unknown User",
+                        role = try {
+                            UserRole.valueOf((document.getString("role") ?: "DRIVER").uppercase())
+                        } catch (e: Exception) {
+                            UserRole.DRIVER
+                        }
+                    )
+                } else {
+                    // Default user profile if document doesn't exist
+                    UserDto(
+                        id = userId,
+                        name = "Unknown User",
+                        role = UserRole.DRIVER
+                    )
+                }
+            }
+    }
+    
+    // Get current user's profile
+    fun getCurrentUserProfile(): Flow<UserDto> {
+        val userId = authService.getCurrentUserId() ?: ""
+        return getUserProfile(userId)
+    }
+    
+    // Simple method to get current user's role (default to DRIVER if not found)
+    suspend fun getCurrentUserRole(): UserRole {
+        val userId = authService.getCurrentUserId() ?: return UserRole.DRIVER
+        return try {
+            val userDoc = getCollection().document(userId).get().await()
+            val roleString = userDoc.getString("role") ?: "DRIVER"
+            UserRole.valueOf(roleString.uppercase())
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not fetch user role, defaulting to DRIVER", e)
+            UserRole.DRIVER
+        }
+    }
+    
+    // Create user document if it doesn't exist (called on first sign-in)
+    suspend fun saveUserIfMissing() {
+        val currentUser = com.google.firebase.auth.FirebaseAuth.getInstance().currentUser
+        if (currentUser == null) {
+            Log.w(TAG, "No authenticated user found")
+            return
+        }
+        
+        val userId = currentUser.uid
+        Log.d(TAG, "Checking user document for: $userId")
+        
+        try {
+            val userDoc = getCollection().document(userId).get().await()
+            
+            if (!userDoc.exists()) {
+                Log.d(TAG, "Creating new user document for: $userId")
+                
+                val userData = mapOf(
+                    "id" to userId,
+                    "name" to (currentUser.displayName ?: "Unknown User"),
+                    "role" to UserRole.DRIVER.name,
+                    "email" to (currentUser.email ?: ""),
+                    "createdAt" to com.google.firebase.Timestamp.now()
+                )
+                
+                getCollection()
+                    .document(userId)
+                    .set(userData)
+                    .await()
+                
+                Log.d(TAG, "✅ User document created successfully for: $userId")
+                toastHelper.showMessage(context, "✅ User profile created")
+            } else {
+                Log.d(TAG, "User document already exists for: $userId")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "❌ Failed to create user document: ${e.message}", e)
+            toastHelper.showError(context, "❌ Failed to create user: ${e.message}")
+            throw e
+        }
+    }
+    
+    // Get drivers for reports
+    suspend fun getDriverUsers(): List<UserDto> {
+        return try {
+            getCollection()
+                .whereEqualTo("role", UserRole.DRIVER.name)
+                .get()
+                .await()
+                .documents
+                .mapNotNull { document ->
+                    try {
+                        UserDto(
+                            id = document.id,
+                            name = document.getString("name") ?: document.getString("displayName") ?: "Unknown Driver",
+                            role = UserRole.DRIVER
+                        )
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Failed to parse driver user: ${document.id}", e)
+                        null
+                    }
+                }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to fetch driver users: ${e.message}", e)
+            emptyList()
+        }
+    }
+    
+    fun getDriverUsersFlow(): Flow<List<UserDto>> {
+        return getCollection()
+            .whereEqualTo("role", UserRole.DRIVER.name)
+            .snapshots()
+            .map { snapshot ->
+                snapshot.documents.mapNotNull { document ->
+                    try {
+                        UserDto(
+                            id = document.id,
+                            name = document.getString("name") ?: document.getString("displayName") ?: "Unknown Driver",
+                            role = UserRole.DRIVER
+                        )
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Failed to parse driver user: ${document.id}", e)
+                        null
+                    }
+                }
+            }
+    }
+    
+    // Admin-only method for creating new driver users
+    suspend fun createDriverUser(name: String, email: String = ""): UserDto {
+        val driverId = java.util.UUID.randomUUID().toString()
+        val userData = mapOf(
+            "id" to driverId,
+            "name" to name,
+            "role" to UserRole.DRIVER.name,
+            "email" to email,
+            "createdAt" to com.google.firebase.Timestamp.now()
+        )
+        
+        getCollection()
+            .document(driverId)
+            .set(userData)
+            .await()
+        
+        return UserDto(
+            id = driverId,
+            name = name,
+            role = UserRole.DRIVER
+        )
+    }
+}

--- a/app/src/main/java/com/fleetmanager/data/remote/VehicleFirestoreService.kt
+++ b/app/src/main/java/com/fleetmanager/data/remote/VehicleFirestoreService.kt
@@ -1,0 +1,121 @@
+package com.fleetmanager.data.remote
+
+import android.content.Context
+import android.util.Log
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.snapshots
+import com.google.firebase.firestore.ktx.toObject
+import com.fleetmanager.domain.model.Vehicle
+import com.fleetmanager.ui.utils.ToastHelper
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class VehicleFirestoreService @Inject constructor(
+    private val firestore: FirebaseFirestore,
+    @ApplicationContext private val context: Context,
+    private val toastHelper: ToastHelper
+) {
+    
+    companion object {
+        private const val TAG = "VehicleFirestoreService"
+        private const val VEHICLES_COLLECTION = "vehicles"
+    }
+    
+    private fun getCollection() = firestore.collection(VEHICLES_COLLECTION)
+    
+    suspend fun saveVehicle(vehicle: Vehicle) {
+        try {
+            getCollection()
+                .document(vehicle.id)
+                .set(vehicle)
+                .await()
+            Log.d(TAG, "Successfully saved vehicle: ${vehicle.id}")
+        } catch (e: Exception) {
+            val errorMessage = "Failed to save vehicle: ${e.message}"
+            Log.e(TAG, errorMessage, e)
+            toastHelper.showError(context, errorMessage)
+            throw e
+        }
+    }
+    
+    suspend fun getVehicles(): List<Vehicle> {
+        return try {
+            getCollection()
+                .whereEqualTo("isActive", true)
+                .get()
+                .await()
+                .documents
+                .mapNotNull { it.toObject<Vehicle>() }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to fetch vehicles: ${e.message}", e)
+            emptyList()
+        }
+    }
+    
+    fun getVehiclesFlow(): Flow<List<Vehicle>> {
+        return getCollection()
+            .whereEqualTo("isActive", true)
+            .snapshots()
+            .map { snapshot ->
+                snapshot.documents.mapNotNull { it.toObject<Vehicle>() }
+            }
+    }
+    
+    suspend fun createVehicle(make: String, model: String, year: Int, licensePlate: String): Vehicle {
+        val vehicleId = java.util.UUID.randomUUID().toString()
+        val vehicle = Vehicle(
+            id = vehicleId,
+            make = make,
+            model = model,
+            year = year,
+            licensePlate = licensePlate,
+            isActive = true
+        )
+        
+        saveVehicle(vehicle)
+        return vehicle
+    }
+    
+    suspend fun initializeSampleVehicles() {
+        val existingVehicles = getVehicles()
+        if (existingVehicles.isEmpty()) {
+            Log.d(TAG, "Initializing sample vehicles...")
+            val sampleVehicles = listOf(
+                Vehicle(
+                    id = "vehicle_1",
+                    make = "Toyota",
+                    model = "Camry",
+                    year = 2020,
+                    licensePlate = "ABC-123",
+                    isActive = true
+                ),
+                Vehicle(
+                    id = "vehicle_2",
+                    make = "Honda",
+                    model = "Civic",
+                    year = 2019,
+                    licensePlate = "XYZ-789",
+                    isActive = true
+                ),
+                Vehicle(
+                    id = "vehicle_3",
+                    make = "Mitsubishi",
+                    model = "Outlander",
+                    year = 2021,
+                    licensePlate = "DEF-456",
+                    isActive = true
+                )
+            )
+            
+            sampleVehicles.forEach { vehicle ->
+                saveVehicle(vehicle)
+            }
+            Log.d(TAG, "✅ Sample vehicles initialized")
+        }
+    }
+}

--- a/app/src/main/java/com/fleetmanager/data/remote/VehicleFirestoreService.kt
+++ b/app/src/main/java/com/fleetmanager/data/remote/VehicleFirestoreService.kt
@@ -46,7 +46,6 @@ class VehicleFirestoreService @Inject constructor(
     suspend fun getVehicles(): List<Vehicle> {
         return try {
             getCollection()
-                .whereEqualTo("isActive", true)
                 .get()
                 .await()
                 .documents
@@ -59,7 +58,6 @@ class VehicleFirestoreService @Inject constructor(
     
     fun getVehiclesFlow(): Flow<List<Vehicle>> {
         return getCollection()
-            .whereEqualTo("isActive", true)
             .snapshots()
             .map { snapshot ->
                 snapshot.documents.mapNotNull { it.toObject<Vehicle>() }
@@ -81,41 +79,4 @@ class VehicleFirestoreService @Inject constructor(
         return vehicle
     }
     
-    suspend fun initializeSampleVehicles() {
-        val existingVehicles = getVehicles()
-        if (existingVehicles.isEmpty()) {
-            Log.d(TAG, "Initializing sample vehicles...")
-            val sampleVehicles = listOf(
-                Vehicle(
-                    id = "vehicle_1",
-                    make = "Toyota",
-                    model = "Camry",
-                    year = 2020,
-                    licensePlate = "ABC-123",
-                    isActive = true
-                ),
-                Vehicle(
-                    id = "vehicle_2",
-                    make = "Honda",
-                    model = "Civic",
-                    year = 2019,
-                    licensePlate = "XYZ-789",
-                    isActive = true
-                ),
-                Vehicle(
-                    id = "vehicle_3",
-                    make = "Mitsubishi",
-                    model = "Outlander",
-                    year = 2021,
-                    licensePlate = "DEF-456",
-                    isActive = true
-                )
-            )
-            
-            sampleVehicles.forEach { vehicle ->
-                saveVehicle(vehicle)
-            }
-            Log.d(TAG, "✅ Sample vehicles initialized")
-        }
-    }
 }

--- a/app/src/main/java/com/fleetmanager/domain/model/Driver.kt
+++ b/app/src/main/java/com/fleetmanager/domain/model/Driver.kt
@@ -1,13 +1,23 @@
 package com.fleetmanager.domain.model
 
+import com.google.firebase.firestore.PropertyName
+
 /**
  * Domain model for driver.
  * This represents the business entity without any framework dependencies.
+ * Firestore-compatible with no-arg constructor and property annotations.
  */
 data class Driver(
-    val id: String,
+    @get:PropertyName("id")
+    val id: String = "",
+    
+    @get:PropertyName("userId")
     val userId: String = "",
-    val name: String,
+    
+    @get:PropertyName("name")
+    val name: String = "",
+    
+    @get:PropertyName("isActive")
     val isActive: Boolean = true
 ) {
     fun isValid(): Boolean {

--- a/app/src/main/java/com/fleetmanager/domain/model/ExpenseTypeItem.kt
+++ b/app/src/main/java/com/fleetmanager/domain/model/ExpenseTypeItem.kt
@@ -1,0 +1,33 @@
+package com.fleetmanager.domain.model
+
+import com.google.firebase.firestore.PropertyName
+
+/**
+ * Domain model for expense type collection item.
+ * This allows for dynamic expense types that can be managed by admins.
+ */
+data class ExpenseTypeItem(
+    @get:PropertyName("id")
+    val id: String = "",
+    
+    @get:PropertyName("name")
+    val name: String = "",
+    
+    @get:PropertyName("displayName") 
+    val displayName: String = "",
+    
+    @get:PropertyName("isActive")
+    val isActive: Boolean = true,
+    
+    @get:PropertyName("createdAt")
+    val createdAt: com.google.firebase.Timestamp = com.google.firebase.Timestamp.now(),
+    
+    @get:PropertyName("updatedAt")
+    val updatedAt: com.google.firebase.Timestamp = com.google.firebase.Timestamp.now()
+) {
+    fun isValid(): Boolean {
+        return id.isNotBlank() &&
+                name.isNotBlank() &&
+                displayName.isNotBlank()
+    }
+}

--- a/app/src/main/java/com/fleetmanager/domain/model/PermissionManager.kt
+++ b/app/src/main/java/com/fleetmanager/domain/model/PermissionManager.kt
@@ -1,7 +1,35 @@
 package com.fleetmanager.domain.model
 
+/**
+ * Centralized permission manager for role-based access control.
+ * All role-based UI and business logic decisions should go through this class.
+ */
 object PermissionManager {
+    
+    // Core permissions
     fun canEdit(userRole: UserRole): Boolean = userRole == UserRole.ADMIN
     fun canDelete(userRole: UserRole): Boolean = userRole == UserRole.ADMIN
     fun canViewAll(userRole: UserRole): Boolean = userRole == UserRole.ADMIN || userRole == UserRole.MANAGER
+    
+    // UI-specific permissions
+    fun canAccessReports(userRole: UserRole): Boolean = userRole != UserRole.DRIVER
+    fun canSeeAdminControls(userRole: UserRole): Boolean = userRole == UserRole.ADMIN
+    
+    // Data management permissions
+    fun canCreateDrivers(userRole: UserRole): Boolean = userRole == UserRole.ADMIN
+    fun canCreateVehicles(userRole: UserRole): Boolean = userRole == UserRole.ADMIN
+    fun canCreateExpenseTypes(userRole: UserRole): Boolean = userRole == UserRole.ADMIN
+    
+    // Report filtering permissions
+    fun canViewAllDriverData(userRole: UserRole): Boolean = userRole == UserRole.ADMIN || userRole == UserRole.MANAGER
+    fun canViewAllVehicleData(userRole: UserRole): Boolean = userRole == UserRole.ADMIN || userRole == UserRole.MANAGER
+    
+    // Navigation permissions
+    fun getAvailableScreens(userRole: UserRole): Set<String> {
+        return when (userRole) {
+            UserRole.DRIVER -> setOf("dashboard", "history", "settings")
+            UserRole.MANAGER -> setOf("dashboard", "history", "reports", "settings")
+            UserRole.ADMIN -> setOf("dashboard", "history", "reports", "settings")
+        }
+    }
 }

--- a/app/src/main/java/com/fleetmanager/domain/model/Vehicle.kt
+++ b/app/src/main/java/com/fleetmanager/domain/model/Vehicle.kt
@@ -1,16 +1,32 @@
 package com.fleetmanager.domain.model
 
+import com.google.firebase.firestore.PropertyName
+
 /**
  * Domain model for vehicle.
  * This represents the business entity without any framework dependencies.
+ * Firestore-compatible with no-arg constructor and property annotations.
  */
 data class Vehicle(
-    val id: String,
+    @get:PropertyName("id")
+    val id: String = "",
+    
+    @get:PropertyName("userId")
     val userId: String = "",
-    val make: String,
-    val model: String,
-    val year: Int,
-    val licensePlate: String,
+    
+    @get:PropertyName("make")
+    val make: String = "",
+    
+    @get:PropertyName("model")
+    val model: String = "",
+    
+    @get:PropertyName("year")
+    val year: Int = 0,
+    
+    @get:PropertyName("licensePlate")
+    val licensePlate: String = "",
+    
+    @get:PropertyName("isActive")
     val isActive: Boolean = true
 ) {
     val displayName: String

--- a/app/src/main/java/com/fleetmanager/ui/navigation/FleetNavigation.kt
+++ b/app/src/main/java/com/fleetmanager/ui/navigation/FleetNavigation.kt
@@ -29,6 +29,7 @@ import com.fleetmanager.ui.screens.report.ReportScreen
 import com.fleetmanager.ui.screens.settings.SettingsScreen
 import com.fleetmanager.data.remote.FirestoreService
 import com.fleetmanager.domain.model.UserRole
+import com.fleetmanager.domain.model.PermissionManager
 import com.fleetmanager.ui.viewmodel.NavigationViewModel
 import androidx.hilt.navigation.compose.hiltViewModel
 
@@ -59,14 +60,10 @@ val allBottomNavItems = listOf(
 )
 
 fun getBottomNavItemsForRole(userRole: UserRole): List<BottomNavItem> {
-    return when (userRole) {
-        UserRole.DRIVER -> {
-            // DRIVER users cannot access Reports tab
-            allBottomNavItems.filter { it.screen != Screen.Reports }
-        }
-        UserRole.MANAGER, UserRole.ADMIN -> {
-            // MANAGER and ADMIN users can access all tabs
-            allBottomNavItems
+    return allBottomNavItems.filter { navItem ->
+        when (navItem.screen) {
+            Screen.Reports -> PermissionManager.canAccessReports(userRole)
+            else -> true // Dashboard, History, Settings are available to all roles
         }
     }
 }

--- a/app/src/main/java/com/fleetmanager/ui/navigation/FleetNavigation.kt
+++ b/app/src/main/java/com/fleetmanager/ui/navigation/FleetNavigation.kt
@@ -27,6 +27,10 @@ import com.fleetmanager.ui.screens.entry.EntryListScreen
 import com.fleetmanager.ui.screens.entry.NewExpenseEntryScreen
 import com.fleetmanager.ui.screens.report.ReportScreen
 import com.fleetmanager.ui.screens.settings.SettingsScreen
+import com.fleetmanager.data.remote.FirestoreService
+import com.fleetmanager.domain.model.UserRole
+import com.fleetmanager.ui.viewmodel.NavigationViewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 
 sealed class Screen(val route: String) {
     object SignIn : Screen("sign_in")
@@ -47,12 +51,25 @@ data class BottomNavItem(
     val icon: ImageVector
 )
 
-val bottomNavItems = listOf(
+val allBottomNavItems = listOf(
     BottomNavItem(Screen.Dashboard, "Dashboard", Icons.Default.Dashboard),
     BottomNavItem(Screen.History, "History", Icons.Default.History),
     BottomNavItem(Screen.Reports, "Reports", Icons.Default.Assessment),
     BottomNavItem(Screen.Settings, "Settings", Icons.Default.Settings)
 )
+
+fun getBottomNavItemsForRole(userRole: UserRole): List<BottomNavItem> {
+    return when (userRole) {
+        UserRole.DRIVER -> {
+            // DRIVER users cannot access Reports tab
+            allBottomNavItems.filter { it.screen != Screen.Reports }
+        }
+        UserRole.MANAGER, UserRole.ADMIN -> {
+            // MANAGER and ADMIN users can access all tabs
+            allBottomNavItems
+        }
+    }
+}
 
 
 @Composable
@@ -79,11 +96,18 @@ fun MainScreenWithBottomNav(
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
     
+    // Create a ViewModel to get user role
+    val navigationViewModel: NavigationViewModel = hiltViewModel()
+    val userRole by navigationViewModel.userRole.collectAsState()
+    
+    val bottomNavItems = userRole?.let { getBottomNavItemsForRole(it) } ?: allBottomNavItems
+    
     Scaffold(
         bottomBar = {
-            if (shouldShowBottomNav(currentRoute)) {
+            if (shouldShowBottomNav(currentRoute, bottomNavItems)) {
                 BottomNavigationBar(
                     currentRoute = currentRoute,
+                    bottomNavItems = bottomNavItems,
                     onNavigate = { route ->
                         navigateToBottomNavDestination(navController, route)
                     }
@@ -102,6 +126,7 @@ fun MainScreenWithBottomNav(
 @Composable
 private fun BottomNavigationBar(
     currentRoute: String?,
+    bottomNavItems: List<BottomNavItem>,
     onNavigate: (String) -> Unit
 ) {
     NavigationBar {
@@ -121,7 +146,7 @@ private fun BottomNavigationBar(
     }
 }
 
-private fun shouldShowBottomNav(currentRoute: String?): Boolean {
+private fun shouldShowBottomNav(currentRoute: String?, bottomNavItems: List<BottomNavItem>): Boolean {
     return currentRoute in bottomNavItems.map { it.screen.route }
 }
 

--- a/app/src/main/java/com/fleetmanager/ui/screens/entry/AddEntryScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/entry/AddEntryScreen.kt
@@ -137,11 +137,11 @@ fun AddEntryScreen(
                     expanded = uiState.driverDropdownExpanded,
                     onDismissRequest = { viewModel.toggleDriverDropdown(false) }
                 ) {
-                    uiState.drivers.forEach { driver ->
+                    uiState.allDriverNames.forEach { driverName ->
                         DropdownMenuItem(
-                            text = { Text(driver.name) },
+                            text = { Text(driverName) },
                             onClick = {
-                                viewModel.selectDriver(driver)
+                                viewModel.updateDriverInput(driverName)
                                 viewModel.toggleDriverDropdown(false)
                             }
                         )
@@ -169,11 +169,11 @@ fun AddEntryScreen(
                     expanded = uiState.vehicleDropdownExpanded,
                     onDismissRequest = { viewModel.toggleVehicleDropdown(false) }
                 ) {
-                    uiState.vehicles.forEach { vehicle ->
+                    uiState.allVehicleNames.forEach { vehicleName ->
                         DropdownMenuItem(
-                            text = { Text(vehicle.displayName) },
+                            text = { Text(vehicleName) },
                             onClick = {
-                                viewModel.selectVehicle(vehicle)
+                                viewModel.updateVehicleInput(vehicleName)
                                 viewModel.toggleVehicleDropdown(false)
                             }
                         )

--- a/app/src/main/java/com/fleetmanager/ui/screens/entry/AddEntryScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/entry/AddEntryScreen.kt
@@ -137,14 +137,21 @@ fun AddEntryScreen(
                     expanded = uiState.driverDropdownExpanded,
                     onDismissRequest = { viewModel.toggleDriverDropdown(false) }
                 ) {
-                    uiState.allDriverNames.forEach { driverName ->
+                    if (uiState.allDriverNames.isEmpty()) {
                         DropdownMenuItem(
-                            text = { Text(driverName) },
-                            onClick = {
-                                viewModel.updateDriverInput(driverName)
-                                viewModel.toggleDriverDropdown(false)
-                            }
+                            text = { Text("No drivers available") },
+                            onClick = { }
                         )
+                    } else {
+                        uiState.allDriverNames.forEach { driverName ->
+                            DropdownMenuItem(
+                                text = { Text(driverName) },
+                                onClick = {
+                                    viewModel.updateDriverInput(driverName)
+                                    viewModel.toggleDriverDropdown(false)
+                                }
+                            )
+                        }
                     }
                 }
             }
@@ -169,14 +176,21 @@ fun AddEntryScreen(
                     expanded = uiState.vehicleDropdownExpanded,
                     onDismissRequest = { viewModel.toggleVehicleDropdown(false) }
                 ) {
-                    uiState.allVehicleNames.forEach { vehicleName ->
+                    if (uiState.allVehicleNames.isEmpty()) {
                         DropdownMenuItem(
-                            text = { Text(vehicleName) },
-                            onClick = {
-                                viewModel.updateVehicleInput(vehicleName)
-                                viewModel.toggleVehicleDropdown(false)
-                            }
+                            text = { Text("No vehicles available") },
+                            onClick = { }
                         )
+                    } else {
+                        uiState.allVehicleNames.forEach { vehicleName ->
+                            DropdownMenuItem(
+                                text = { Text(vehicleName) },
+                                onClick = {
+                                    viewModel.updateVehicleInput(vehicleName)
+                                    viewModel.toggleVehicleDropdown(false)
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/fleetmanager/ui/screens/entry/NewExpenseEntryScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/entry/NewExpenseEntryScreen.kt
@@ -136,10 +136,12 @@ fun NewExpenseEntryScreen(
                     expanded = uiState.expenseTypeDropdownExpanded,
                     onDismissRequest = { viewModel.toggleExpenseTypeDropdown(false) }
                 ) {
-                    ExpenseType.values().forEach { expenseType ->
+                    uiState.allExpenseTypes.forEach { expenseTypeName ->
                         DropdownMenuItem(
-                            text = { Text(expenseType.displayName) },
+                            text = { Text(expenseTypeName) },
                             onClick = {
+                                // Find the matching ExpenseType enum or use default
+                                val expenseType = ExpenseType.values().find { it.displayName == expenseTypeName } ?: ExpenseType.OTHER
                                 viewModel.selectExpenseType(expenseType)
                                 viewModel.toggleExpenseTypeDropdown(false)
                             }
@@ -179,11 +181,11 @@ fun NewExpenseEntryScreen(
                     expanded = uiState.driverDropdownExpanded,
                     onDismissRequest = { viewModel.toggleDriverDropdown(false) }
                 ) {
-                    uiState.drivers.forEach { driver ->
+                    uiState.allDriverNames.forEach { driverName ->
                         DropdownMenuItem(
-                            text = { Text(driver.name) },
+                            text = { Text(driverName) },
                             onClick = {
-                                viewModel.selectDriver(driver)
+                                viewModel.updateDriverInput(driverName)
                                 viewModel.toggleDriverDropdown(false)
                             }
                         )
@@ -211,11 +213,11 @@ fun NewExpenseEntryScreen(
                     expanded = uiState.vehicleDropdownExpanded,
                     onDismissRequest = { viewModel.toggleVehicleDropdown(false) }
                 ) {
-                    uiState.vehicles.forEach { vehicle ->
+                    uiState.allVehicleNames.forEach { vehicleName ->
                         DropdownMenuItem(
-                            text = { Text(vehicle.displayName) },
+                            text = { Text(vehicleName) },
                             onClick = {
-                                viewModel.selectVehicle(vehicle)
+                                viewModel.updateVehicleInput(vehicleName)
                                 viewModel.toggleVehicleDropdown(false)
                             }
                         )

--- a/app/src/main/java/com/fleetmanager/ui/screens/entry/NewExpenseEntryScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/entry/NewExpenseEntryScreen.kt
@@ -136,16 +136,23 @@ fun NewExpenseEntryScreen(
                     expanded = uiState.expenseTypeDropdownExpanded,
                     onDismissRequest = { viewModel.toggleExpenseTypeDropdown(false) }
                 ) {
-                    uiState.allExpenseTypes.forEach { expenseTypeName ->
+                    if (uiState.allExpenseTypes.isEmpty()) {
                         DropdownMenuItem(
-                            text = { Text(expenseTypeName) },
-                            onClick = {
-                                // Find the matching ExpenseType enum or use default
-                                val expenseType = ExpenseType.values().find { it.displayName == expenseTypeName } ?: ExpenseType.OTHER
-                                viewModel.selectExpenseType(expenseType)
-                                viewModel.toggleExpenseTypeDropdown(false)
-                            }
+                            text = { Text("No expense types available") },
+                            onClick = { }
                         )
+                    } else {
+                        uiState.allExpenseTypes.forEach { expenseTypeName ->
+                            DropdownMenuItem(
+                                text = { Text(expenseTypeName) },
+                                onClick = {
+                                    // Find the matching ExpenseType enum or use default
+                                    val expenseType = ExpenseType.values().find { it.displayName == expenseTypeName } ?: ExpenseType.OTHER
+                                    viewModel.selectExpenseType(expenseType)
+                                    viewModel.toggleExpenseTypeDropdown(false)
+                                }
+                            )
+                        }
                     }
                 }
             }
@@ -181,14 +188,21 @@ fun NewExpenseEntryScreen(
                     expanded = uiState.driverDropdownExpanded,
                     onDismissRequest = { viewModel.toggleDriverDropdown(false) }
                 ) {
-                    uiState.allDriverNames.forEach { driverName ->
+                    if (uiState.allDriverNames.isEmpty()) {
                         DropdownMenuItem(
-                            text = { Text(driverName) },
-                            onClick = {
-                                viewModel.updateDriverInput(driverName)
-                                viewModel.toggleDriverDropdown(false)
-                            }
+                            text = { Text("No drivers available") },
+                            onClick = { }
                         )
+                    } else {
+                        uiState.allDriverNames.forEach { driverName ->
+                            DropdownMenuItem(
+                                text = { Text(driverName) },
+                                onClick = {
+                                    viewModel.updateDriverInput(driverName)
+                                    viewModel.toggleDriverDropdown(false)
+                                }
+                            )
+                        }
                     }
                 }
             }
@@ -213,14 +227,21 @@ fun NewExpenseEntryScreen(
                     expanded = uiState.vehicleDropdownExpanded,
                     onDismissRequest = { viewModel.toggleVehicleDropdown(false) }
                 ) {
-                    uiState.allVehicleNames.forEach { vehicleName ->
+                    if (uiState.allVehicleNames.isEmpty()) {
                         DropdownMenuItem(
-                            text = { Text(vehicleName) },
-                            onClick = {
-                                viewModel.updateVehicleInput(vehicleName)
-                                viewModel.toggleVehicleDropdown(false)
-                            }
+                            text = { Text("No vehicles available") },
+                            onClick = { }
                         )
+                    } else {
+                        uiState.allVehicleNames.forEach { vehicleName ->
+                            DropdownMenuItem(
+                                text = { Text(vehicleName) },
+                                onClick = {
+                                    viewModel.updateVehicleInput(vehicleName)
+                                    viewModel.toggleVehicleDropdown(false)
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/fleetmanager/ui/screens/report/ReportScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/report/ReportScreen.kt
@@ -132,7 +132,7 @@ fun ReportScreen(
             CollapsibleFiltersSection(
                 isExpanded = isFilterExpanded,
                 onToggleExpanded = { viewModel.toggleFilterPanel() },
-                drivers = uiState.drivers.map { it.name },
+                drivers = uiState.driverUsers.map { it.name },
                 vehicles = uiState.vehicles.map { it.displayName },
                 types = uiState.availableTypes,
                 selectedDriver = uiState.selectedDriver,

--- a/app/src/main/java/com/fleetmanager/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/settings/SettingsScreen.kt
@@ -3,8 +3,10 @@ package com.fleetmanager.ui.screens.settings
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.CloudSync
+import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.Feedback
 import androidx.compose.material.icons.filled.Help
 import androidx.compose.material.icons.filled.Info
@@ -13,9 +15,12 @@ import androidx.compose.material.icons.filled.Logout
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.filled.Receipt
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.Sync
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -54,6 +59,21 @@ fun SettingsScreen(
                     title = "Sign Out",
                     subtitle = "Sign out of your account",
                     onClick = { viewModel.signOut() }
+                )
+            }
+        }
+
+        // Admin Section (Only visible to ADMIN users)
+        if (uiState.isAdmin) {
+            item {
+                AdminSection(
+                    onAddDriver = { name, email -> viewModel.addDriver(name, email) },
+                    onAddVehicle = { make, model, year, licensePlate -> 
+                        viewModel.addVehicle(make, model, year, licensePlate) 
+                    },
+                    onAddExpenseType = { name, displayName -> 
+                        viewModel.addExpenseType(name, displayName) 
+                    }
                 )
             }
         }
@@ -178,4 +198,230 @@ fun SettingsScreen(
             }
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AdminSection(
+    onAddDriver: (String, String) -> Unit,
+    onAddVehicle: (String, String, Int, String) -> Unit,
+    onAddExpenseType: (String, String) -> Unit
+) {
+    var showAddDriverDialog by remember { mutableStateOf(false) }
+    var showAddVehicleDialog by remember { mutableStateOf(false) }
+    var showAddExpenseTypeDialog by remember { mutableStateOf(false) }
+
+    SettingsSection(title = "Admin Controls") {
+        SettingsItem(
+            icon = Icons.Default.PersonAdd,
+            title = "Add Driver",
+            subtitle = "Create a new driver user account",
+            onClick = { showAddDriverDialog = true }
+        )
+        
+        SettingsItem(
+            icon = Icons.Default.DirectionsCar,
+            title = "Add Vehicle",
+            subtitle = "Add a new vehicle to the fleet",
+            onClick = { showAddVehicleDialog = true }
+        )
+        
+        SettingsItem(
+            icon = Icons.Default.Receipt,
+            title = "Add Expense Type",
+            subtitle = "Create a new expense category",
+            onClick = { showAddExpenseTypeDialog = true }
+        )
+    }
+
+    // Add Driver Dialog
+    if (showAddDriverDialog) {
+        AddDriverDialog(
+            onDismiss = { showAddDriverDialog = false },
+            onConfirm = { name, email ->
+                onAddDriver(name, email)
+                showAddDriverDialog = false
+            }
+        )
+    }
+
+    // Add Vehicle Dialog
+    if (showAddVehicleDialog) {
+        AddVehicleDialog(
+            onDismiss = { showAddVehicleDialog = false },
+            onConfirm = { make, model, year, licensePlate ->
+                onAddVehicle(make, model, year, licensePlate)
+                showAddVehicleDialog = false
+            }
+        )
+    }
+
+    // Add Expense Type Dialog
+    if (showAddExpenseTypeDialog) {
+        AddExpenseTypeDialog(
+            onDismiss = { showAddExpenseTypeDialog = false },
+            onConfirm = { name, displayName ->
+                onAddExpenseType(name, displayName)
+                showAddExpenseTypeDialog = false
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AddDriverDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (String, String) -> Unit
+) {
+    var name by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add New Driver") },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Driver Name *") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = email,
+                    onValueChange = { email = it },
+                    label = { Text("Email (Optional)") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(name, email) },
+                enabled = name.isNotBlank()
+            ) {
+                Text("Add Driver")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AddVehicleDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (String, String, Int, String) -> Unit
+) {
+    var make by remember { mutableStateOf("") }
+    var model by remember { mutableStateOf("") }
+    var year by remember { mutableStateOf("") }
+    var licensePlate by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add New Vehicle") },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                OutlinedTextField(
+                    value = make,
+                    onValueChange = { make = it },
+                    label = { Text("Make *") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = model,
+                    onValueChange = { model = it },
+                    label = { Text("Model *") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = year,
+                    onValueChange = { year = it },
+                    label = { Text("Year *") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = licensePlate,
+                    onValueChange = { licensePlate = it },
+                    label = { Text("License Plate *") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { 
+                    val yearInt = year.toIntOrNull() ?: 0
+                    onConfirm(make, model, yearInt, licensePlate) 
+                },
+                enabled = make.isNotBlank() && model.isNotBlank() && 
+                         year.toIntOrNull() != null && licensePlate.isNotBlank()
+            ) {
+                Text("Add Vehicle")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AddExpenseTypeDialog(
+    onDismiss: () -> Unit,
+    onConfirm: (String, String) -> Unit
+) {
+    var name by remember { mutableStateOf("") }
+    var displayName by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add New Expense Type") },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Internal Name *") },
+                    placeholder = { Text("e.g., PARKING") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = displayName,
+                    onValueChange = { displayName = it },
+                    label = { Text("Display Name *") },
+                    placeholder = { Text("e.g., Parking Fees") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(name, displayName) },
+                enabled = name.isNotBlank() && displayName.isNotBlank()
+            ) {
+                Text("Add Type")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        }
+    )
 }

--- a/app/src/main/java/com/fleetmanager/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/settings/SettingsScreen.kt
@@ -64,7 +64,7 @@ fun SettingsScreen(
         }
 
         // Admin Section (Only visible to ADMIN users)
-        if (uiState.isAdmin) {
+        if (uiState.canSeeAdminControls) {
             item {
                 AdminSection(
                     onAddDriver = { name, email -> viewModel.addDriver(name, email) },

--- a/app/src/main/java/com/fleetmanager/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/settings/SettingsScreen.kt
@@ -215,7 +215,7 @@ private fun AdminSection(
         SettingsItem(
             icon = Icons.Default.PersonAdd,
             title = "Add Driver",
-            subtitle = "Create a new driver user account",
+            subtitle = "Create a new user with DRIVER role",
             onClick = { showAddDriverDialog = true }
         )
         
@@ -279,21 +279,28 @@ private fun AddDriverDialog(
 
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Add New Driver") },
+        title = { Text("Add New Driver User") },
         text = {
             Column(
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
+                Text(
+                    text = "This will create a new user with DRIVER role in the users collection.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
                 OutlinedTextField(
                     value = name,
                     onValueChange = { name = it },
-                    label = { Text("Driver Name *") },
+                    label = { Text("Full Name *") },
+                    placeholder = { Text("e.g., John Smith") },
                     modifier = Modifier.fillMaxWidth()
                 )
                 OutlinedTextField(
                     value = email,
                     onValueChange = { email = it },
-                    label = { Text("Email (Optional)") },
+                    label = { Text("Email Address *") },
+                    placeholder = { Text("e.g., john@example.com") },
                     modifier = Modifier.fillMaxWidth()
                 )
             }
@@ -301,9 +308,9 @@ private fun AddDriverDialog(
         confirmButton = {
             TextButton(
                 onClick = { onConfirm(name, email) },
-                enabled = name.isNotBlank()
+                enabled = name.isNotBlank() && email.isNotBlank()
             ) {
-                Text("Add Driver")
+                Text("Create Driver")
             }
         },
         dismissButton = {

--- a/app/src/main/java/com/fleetmanager/ui/viewmodel/AddEntryViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/viewmodel/AddEntryViewModel.kt
@@ -7,11 +7,7 @@ import com.fleetmanager.domain.model.Vehicle
 import com.fleetmanager.data.remote.UserFirestoreService
 import com.fleetmanager.data.remote.VehicleFirestoreService
 import com.fleetmanager.data.dto.UserDto
-import com.fleetmanager.domain.usecase.GetActiveDriversUseCase
-import com.fleetmanager.domain.usecase.GetActiveVehiclesUseCase
 import com.fleetmanager.domain.usecase.SaveDailyEntryUseCase
-import com.fleetmanager.domain.usecase.SaveDriverUseCase
-import com.fleetmanager.domain.usecase.SaveVehicleUseCase
 import com.fleetmanager.domain.validation.InputValidator
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
@@ -70,13 +66,9 @@ data class AddEntryUiState(
 
 @HiltViewModel
 class AddEntryViewModel @Inject constructor(
-    private val getActiveDriversUseCase: GetActiveDriversUseCase,
-    private val getActiveVehiclesUseCase: GetActiveVehiclesUseCase,
     private val userFirestoreService: UserFirestoreService,
     private val vehicleFirestoreService: VehicleFirestoreService,
     private val saveDailyEntryUseCase: SaveDailyEntryUseCase,
-    private val saveDriverUseCase: SaveDriverUseCase,
-    private val saveVehicleUseCase: SaveVehicleUseCase,
     private val validator: InputValidator
 ) : BaseViewModel<AddEntryUiState>() {
     
@@ -122,7 +114,7 @@ class AddEntryViewModel @Inject constructor(
         updateState { 
             it.copy(
                 driverInput = input,
-                selectedDriver = it.drivers.find { driver -> driver.name == input }
+                selectedDriver = null // We no longer maintain selectedDriver state
             ) 
         }
     }

--- a/app/src/main/java/com/fleetmanager/ui/viewmodel/AddExpenseViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/viewmodel/AddExpenseViewModel.kt
@@ -10,11 +10,7 @@ import com.fleetmanager.data.remote.UserFirestoreService
 import com.fleetmanager.data.remote.VehicleFirestoreService
 import com.fleetmanager.data.remote.ExpenseTypeFirestoreService
 import com.fleetmanager.data.dto.UserDto
-import com.fleetmanager.domain.usecase.GetActiveDriversUseCase
-import com.fleetmanager.domain.usecase.GetActiveVehiclesUseCase
 import com.fleetmanager.domain.usecase.SaveExpenseUseCase
-import com.fleetmanager.domain.usecase.SaveDriverUseCase
-import com.fleetmanager.domain.usecase.SaveVehicleUseCase
 import com.fleetmanager.domain.validation.InputValidator
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
@@ -72,14 +68,10 @@ data class AddExpenseUiState(
 
 @HiltViewModel
 class AddExpenseViewModel @Inject constructor(
-    private val getActiveDriversUseCase: GetActiveDriversUseCase,
-    private val getActiveVehiclesUseCase: GetActiveVehiclesUseCase,
     private val userFirestoreService: UserFirestoreService,
     private val vehicleFirestoreService: VehicleFirestoreService,
     private val expenseTypeFirestoreService: ExpenseTypeFirestoreService,
     private val saveExpenseUseCase: SaveExpenseUseCase,
-    private val saveDriverUseCase: SaveDriverUseCase,
-    private val saveVehicleUseCase: SaveVehicleUseCase,
     private val validator: InputValidator
 ) : BaseViewModel<AddExpenseUiState>() {
     
@@ -126,7 +118,7 @@ class AddExpenseViewModel @Inject constructor(
         updateState { 
             it.copy(
                 driverInput = input,
-                selectedDriver = it.drivers.find { driver -> driver.name == input }
+                selectedDriver = null // We no longer maintain selectedDriver state
             ) 
         }
     }

--- a/app/src/main/java/com/fleetmanager/ui/viewmodel/NavigationViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/viewmodel/NavigationViewModel.kt
@@ -1,0 +1,38 @@
+package com.fleetmanager.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.fleetmanager.data.remote.FirestoreService
+import com.fleetmanager.domain.model.UserRole
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class NavigationViewModel @Inject constructor(
+    private val firestoreService: FirestoreService
+) : ViewModel() {
+    
+    private val _userRole = MutableStateFlow<UserRole?>(null)
+    val userRole: StateFlow<UserRole?> = _userRole.asStateFlow()
+    
+    init {
+        loadUserRole()
+    }
+    
+    private fun loadUserRole() {
+        viewModelScope.launch {
+            try {
+                firestoreService.getCurrentUserProfile().collect { userProfile ->
+                    _userRole.value = userProfile.role
+                }
+            } catch (e: Exception) {
+                // Default to DRIVER role if there's an error
+                _userRole.value = UserRole.DRIVER
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/fleetmanager/ui/viewmodel/ReportViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/viewmodel/ReportViewModel.kt
@@ -3,7 +3,9 @@ package com.fleetmanager.ui.viewmodel
 import com.fleetmanager.auth.AuthService
 import com.fleetmanager.data.preferences.ReportFilterPreferences
 import com.fleetmanager.data.preferences.ReportPreferencesDataStore
-import com.fleetmanager.data.remote.FirestoreService
+import com.fleetmanager.data.remote.UserFirestoreService
+import com.fleetmanager.data.remote.VehicleFirestoreService
+import com.fleetmanager.data.remote.ExpenseTypeFirestoreService
 import com.fleetmanager.data.dto.UserDto
 import com.fleetmanager.domain.model.Driver
 import com.fleetmanager.domain.model.Vehicle
@@ -121,7 +123,9 @@ class ReportViewModel @Inject constructor(
     private val getReportDataRealtimeUseCase: GetReportDataRealtimeUseCase,
     private val getActiveDriversUseCase: GetActiveDriversUseCase,
     private val getActiveVehiclesUseCase: GetActiveVehiclesUseCase,
-    private val firestoreService: FirestoreService,
+    private val userFirestoreService: UserFirestoreService,
+    private val vehicleFirestoreService: VehicleFirestoreService,
+    private val expenseTypeFirestoreService: ExpenseTypeFirestoreService,
     private val authService: AuthService,
     private val reportPreferencesDataStore: ReportPreferencesDataStore
 ) : BaseViewModel<ReportUiState>() {
@@ -140,7 +144,9 @@ class ReportViewModel @Inject constructor(
                 updateState { it.copy(errorMessage = error) }
             }
         ) {
-            firestoreService.initializeDefaultData()
+            // Initialize default data in parallel
+            expenseTypeFirestoreService.initializeDefaultExpenseTypes()
+            vehicleFirestoreService.initializeSampleVehicles()
         }
     }
     
@@ -155,9 +161,9 @@ class ReportViewModel @Inject constructor(
         ) {
             combine(
                 getReportDataRealtimeUseCase(),
-                firestoreService.getDriverUsersFlow(),
-                firestoreService.getVehiclesFromCollectionFlow(),
-                firestoreService.getExpenseTypesFlow()
+                userFirestoreService.getDriverUsersFlow(),
+                vehicleFirestoreService.getVehiclesFlow(),
+                expenseTypeFirestoreService.getExpenseTypesFlow()
             ) { reportData, driverUsers, vehicles, expenseTypes ->
                 val allEntries = mutableListOf<ReportEntry>()
                 

--- a/app/src/main/java/com/fleetmanager/ui/viewmodel/ReportViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/viewmodel/ReportViewModel.kt
@@ -133,21 +133,8 @@ class ReportViewModel @Inject constructor(
     override fun getInitialState() = ReportUiState()
     
     init {
-        initializeData()
         loadReportData()
         loadUserContext()
-    }
-    
-    private fun initializeData() {
-        executeAsync(
-            onError = { error ->
-                updateState { it.copy(errorMessage = error) }
-            }
-        ) {
-            // Initialize default data in parallel
-            expenseTypeFirestoreService.initializeDefaultExpenseTypes()
-            vehicleFirestoreService.initializeSampleVehicles()
-        }
     }
     
     private fun loadReportData() {

--- a/app/src/main/java/com/fleetmanager/ui/viewmodel/ReportViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/viewmodel/ReportViewModel.kt
@@ -3,8 +3,11 @@ package com.fleetmanager.ui.viewmodel
 import com.fleetmanager.auth.AuthService
 import com.fleetmanager.data.preferences.ReportFilterPreferences
 import com.fleetmanager.data.preferences.ReportPreferencesDataStore
+import com.fleetmanager.data.remote.FirestoreService
+import com.fleetmanager.data.dto.UserDto
 import com.fleetmanager.domain.model.Driver
 import com.fleetmanager.domain.model.Vehicle
+import com.fleetmanager.domain.model.ExpenseTypeItem
 import com.fleetmanager.domain.usecase.GetActiveDriversUseCase
 import com.fleetmanager.domain.usecase.GetActiveVehiclesUseCase
 import com.fleetmanager.domain.usecase.GetReportDataRealtimeUseCase
@@ -46,8 +49,9 @@ data class GroupedTotal(
 data class ReportUiState(
     val allEntries: List<ReportEntry> = emptyList(),
     val filteredEntries: List<ReportEntry> = emptyList(),
-    val drivers: List<Driver> = emptyList(),
+    val driverUsers: List<UserDto> = emptyList(),
     val vehicles: List<Vehicle> = emptyList(),
+    val expenseTypes: List<ExpenseTypeItem> = emptyList(),
     val availableTypes: List<String> = emptyList(),
     val selectedDriver: String? = null,
     val selectedVehicle: String? = null,
@@ -117,6 +121,7 @@ class ReportViewModel @Inject constructor(
     private val getReportDataRealtimeUseCase: GetReportDataRealtimeUseCase,
     private val getActiveDriversUseCase: GetActiveDriversUseCase,
     private val getActiveVehiclesUseCase: GetActiveVehiclesUseCase,
+    private val firestoreService: FirestoreService,
     private val authService: AuthService,
     private val reportPreferencesDataStore: ReportPreferencesDataStore
 ) : BaseViewModel<ReportUiState>() {
@@ -124,8 +129,19 @@ class ReportViewModel @Inject constructor(
     override fun getInitialState() = ReportUiState()
     
     init {
+        initializeData()
         loadReportData()
         loadUserContext()
+    }
+    
+    private fun initializeData() {
+        executeAsync(
+            onError = { error ->
+                updateState { it.copy(errorMessage = error) }
+            }
+        ) {
+            firestoreService.initializeDefaultData()
+        }
     }
     
     private fun loadReportData() {
@@ -139,9 +155,10 @@ class ReportViewModel @Inject constructor(
         ) {
             combine(
                 getReportDataRealtimeUseCase(),
-                getActiveDriversUseCase(),
-                getActiveVehiclesUseCase()
-            ) { reportData, drivers, vehicles ->
+                firestoreService.getDriverUsersFlow(),
+                firestoreService.getVehiclesFromCollectionFlow(),
+                firestoreService.getExpenseTypesFlow()
+            ) { reportData, driverUsers, vehicles, expenseTypes ->
                 val allEntries = mutableListOf<ReportEntry>()
                 
                 // Convert daily entries to report entries
@@ -157,17 +174,21 @@ class ReportViewModel @Inject constructor(
                 // Sort by date descending
                 allEntries.sortByDescending { it.date }
                 
-                // Get unique types for filtering
-                val availableTypes = allEntries.map { it.typeDisplayName }.distinct().sorted()
+                // Get unique types for filtering (combine from entries and expense types)
+                val typesFromEntries = allEntries.map { it.typeDisplayName }.distinct()
+                val typesFromExpenseTypes = expenseTypes.map { it.displayName }
+                val availableTypes = (typesFromEntries + typesFromExpenseTypes).distinct().sorted()
                 
-                Triple(allEntries, drivers, vehicles to availableTypes)
-            }.collect { (allEntries, drivers, vehiclesAndTypes) ->
-                val (vehicles, availableTypes) = vehiclesAndTypes
+                Pair(allEntries, Triple(driverUsers, vehicles, Pair(expenseTypes, availableTypes)))
+            }.collect { (allEntries, data) ->
+                val (driverUsers, vehicles, expenseTypesAndTypes) = data
+                val (expenseTypes, availableTypes) = expenseTypesAndTypes
                 updateState { currentState ->
                     val newState = currentState.copy(
                         allEntries = allEntries,
-                        drivers = drivers,
+                        driverUsers = driverUsers,
                         vehicles = vehicles,
+                        expenseTypes = expenseTypes,
                         availableTypes = availableTypes,
                         isLoading = false,
                         errorMessage = null
@@ -274,7 +295,7 @@ class ReportViewModel @Inject constructor(
                 updateState { currentState ->
                     currentState.copy(
                         currentUserId = userId,
-                        isCurrentUserDriver = userId != null && isUserADriver(userId, currentState.drivers)
+                        isCurrentUserDriver = userId != null && isUserADriver(userId, currentState.driverUsers)
                     )
                 }
             }
@@ -295,7 +316,7 @@ class ReportViewModel @Inject constructor(
                     // Auto-fill driver and vehicle for drivers
                     val autoSelectedDriver = if (state.isCurrentUserDriver) {
                         // Find the driver that matches the current user
-                        val matchingDriver = state.drivers.find { driver ->
+                        val matchingDriver = state.driverUsers.find { driver ->
                             driver.id == userId
                         }
                         preferences.selectedDriver ?: matchingDriver?.name
@@ -356,8 +377,8 @@ class ReportViewModel @Inject constructor(
         }
     }
     
-    private fun isUserADriver(userId: String, drivers: List<Driver>): Boolean {
-        return drivers.any { driver -> 
+    private fun isUserADriver(userId: String, driverUsers: List<UserDto>): Boolean {
+        return driverUsers.any { driver -> 
             driver.id == userId
         }
     }

--- a/app/src/main/java/com/fleetmanager/ui/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/viewmodel/SettingsViewModel.kt
@@ -151,10 +151,15 @@ class SettingsViewModel @Inject constructor(
     }
     
     // Admin-only functions with permission checks
-    fun addDriver(name: String, email: String = "") {
+    fun addDriver(name: String, email: String) {
         val currentRole = _uiState.value.currentUserRole
         if (currentRole == null || !PermissionManager.canCreateDrivers(currentRole)) {
             updateState { it.copy(error = "You don't have permission to create drivers") }
+            return
+        }
+        
+        if (name.isBlank() || email.isBlank()) {
+            updateState { it.copy(error = "Name and email are required") }
             return
         }
         
@@ -165,7 +170,7 @@ class SettingsViewModel @Inject constructor(
         ) {
             val driver = userFirestoreService.createDriverUser(name, email)
             updateState { 
-                it.copy(message = "Driver '${driver.name}' added successfully") 
+                it.copy(message = "Driver user '${driver.name}' created successfully with email: $email") 
             }
         }
     }


### PR DESCRIPTION
Implement role-based access control, dynamic report filtering from Firestore, and admin-only data management tools, with a significant refactoring of data services and permission logic.

The monolithic `FirestoreService` was split into dedicated sub-services (`UserFirestoreService`, `VehicleFirestoreService`, `ExpenseTypeFirestoreService`) and a centralized `PermissionManager` was introduced. This refactoring improves maintainability, testability, and scalability by separating concerns and removing scattered role-based logic from ViewModels.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1f48f82-5ca4-44ad-a612-9bebfb69eec6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c1f48f82-5ca4-44ad-a612-9bebfb69eec6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

