### PR TITLE
Fetch vehicles and expense types from collection

### DIFF
--- a/app/src/main/java/com/fleetmanager/domain/model/Expense.kt
+++ b/app/src/main/java/com/fleetmanager/domain/model/Expense.kt
@@ -18,7 +18,7 @@ data class Expense(
     val userId: String = "",
     
     @get:PropertyName("type")
-    val type: ExpenseType = ExpenseType.FUEL,
+    val type: ExpenseType = ExpenseType.OTHER,
     
     @get:PropertyName("amount")
     val amount: Double = 0.0,

--- a/app/src/main/java/com/fleetmanager/ui/viewmodel/AddExpenseViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/viewmodel/AddExpenseViewModel.kt
@@ -26,7 +26,7 @@ data class AddExpenseUiState(
     val selectedVehicle: Vehicle? = null,
     val driverInput: String = "",
     val vehicleInput: String = "",
-    val selectedExpenseType: ExpenseType = ExpenseType.FUEL,
+    val selectedExpenseType: ExpenseType = ExpenseType.OTHER,
     val date: Date = Date(),
     val amount: String = "",
     val notes: String = "",
@@ -96,10 +96,19 @@ class AddExpenseViewModel @Inject constructor(
                 Triple(driverUsers, vehicles, expenseTypes)
             }.collect { (driverUsers, vehicles, expenseTypes) ->
                 updateState { currentState ->
+                    // If this is the first load and we have expense types, select the first one
+                    val selectedExpenseType = if (currentState.expenseTypes.isEmpty() && expenseTypes.isNotEmpty()) {
+                        // Find the matching ExpenseType enum for the first expense type, or use OTHER as fallback
+                        ExpenseType.values().find { it.displayName == expenseTypes.first().displayName } ?: ExpenseType.OTHER
+                    } else {
+                        currentState.selectedExpenseType
+                    }
+                    
                     currentState.copy(
                         driverUsers = driverUsers,
                         vehicles = vehicles,
-                        expenseTypes = expenseTypes
+                        expenseTypes = expenseTypes,
+                        selectedExpenseType = selectedExpenseType
                     )
                 }
             }


### PR DESCRIPTION
Remove hardcoded `ExpenseType.FUEL` default and dynamically select the first expense type from the collection.

The task requested removing hardcoded values for vehicles and expense types. While vehicles were already dynamic, the default `ExpenseType` was hardcoded to `FUEL`. This PR updates the `AddExpenseViewModel` to select the first available expense type from the collection and changes the default in the `Expense` data class to `OTHER` to reflect this dynamic behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-35e0277a-202f-460a-9e52-ec79ccf7aeae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-35e0277a-202f-460a-9e52-ec79ccf7aeae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

