### PR TITLE
Improve analytics navigation flow

### DIFF
--- a/app/src/main/java/com/fleetmanager/ui/screens/analytics/AnalyticsScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/analytics/AnalyticsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.filled.DirectionsCar
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -15,6 +16,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import java.time.DayOfWeek
 import com.fleetmanager.ui.screens.analytics.components.*
+import com.fleetmanager.ui.screens.analytics.model.AnalyticsCategory
 import com.fleetmanager.ui.screens.analytics.model.AnalyticsData
 import com.fleetmanager.ui.screens.analytics.model.AnalyticsPanel
 import com.fleetmanager.ui.screens.analytics.utils.AnalyticsAdapters
@@ -36,57 +38,76 @@ fun AnalyticsScreen(
     val timeFilter by viewModel.timeFilter.collectAsState()
     val userProfile by viewModel.userProfile.collectAsState()
     
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp)
-            .verticalScroll(rememberScrollState())
-    ) {
-        // Screen Header
-        com.fleetmanager.ui.components.ScreenHeader(
-            title = "Analytics",
-            userName = userProfile.name,
-            profilePictureUrl = userProfile.profilePictureUrl,
-            onProfileClick = onNavigateToProfile?.let { com.fleetmanager.ui.components.rememberProfileClickHandler(it) },
-            modifier = Modifier.padding(bottom = 16.dp)
-        )
-        
-        // Time Filter
-        TimeFilterRow(
-            selectedFilter = timeFilter,
-            onFilterSelected = { filter -> viewModel.setTimeFilter(filter) },
-            modifier = Modifier.padding(bottom = 16.dp)
-        )
-        
-        // GENERALIZATION: Analytics menu for panel selection
-        AnalyticsMenu(
-            selectedPanel = selectedPanel,
-            onPanelSelected = { panel -> viewModel.selectPanel(panel) },
-            onShowAll = { viewModel.showAllPanels() },
-            modifier = Modifier.padding(bottom = 16.dp)
-        )
-        
-        // GENERALIZATION: Conditional panel rendering based on selection
-        selectedPanel?.let { panel ->
-            // Show selected panel only
-            ShowSelectedPanel(
-                panel = panel,
-                uiState = uiState,
-                analyticsData = analyticsData,
-                viewModel = viewModel
-            )
-        } ?: run {
-            // Show all panels (default view)
-            ShowAllPanels(
-                uiState = uiState,
-                analyticsData = analyticsData,
-                viewModel = viewModel
+    var selectedCategory by rememberSaveable { mutableStateOf(AnalyticsCategory.PERFORMANCE) }
+
+    val scrollState = rememberScrollState()
+
+    Scaffold(
+        bottomBar = {
+            AnalyticsCategoryNavigationBar(
+                selectedCategory = selectedCategory,
+                onCategorySelected = { selectedCategory = it }
             )
         }
-        
-        Spacer(modifier = Modifier.height(16.dp))
-    }
-    
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(16.dp)
+                .verticalScroll(scrollState)
+        ) {
+            // Screen Header
+            com.fleetmanager.ui.components.ScreenHeader(
+                title = "Analytics",
+                userName = userProfile.name,
+                profilePictureUrl = userProfile.profilePictureUrl,
+                onProfileClick = onNavigateToProfile?.let { com.fleetmanager.ui.components.rememberProfileClickHandler(it) },
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            // Time Filter
+            TimeFilterRow(
+                selectedFilter = timeFilter,
+                onFilterSelected = { filter -> viewModel.setTimeFilter(filter) },
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            // GENERALIZATION: Analytics menu for panel selection
+            AnalyticsMenu(
+                selectedPanel = selectedPanel,
+                selectedCategory = selectedCategory,
+                onCategorySelected = { selectedCategory = it },
+                onPanelSelected = { panel ->
+                    selectedCategory = panel.category
+                    viewModel.selectPanel(panel)
+                },
+                onShowAll = { viewModel.showAllPanels() },
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            // GENERALIZATION: Conditional panel rendering based on selection
+            selectedPanel?.let { panel ->
+                // Show selected panel only
+                ShowSelectedPanel(
+                    panel = panel,
+                    uiState = uiState,
+                    analyticsData = analyticsData,
+                    viewModel = viewModel
+                )
+            } ?: run {
+                // Show panels within the selected category for quicker access
+                ShowCategoryPanels(
+                    category = selectedCategory,
+                    uiState = uiState,
+                    analyticsData = analyticsData,
+                    viewModel = viewModel
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+
     // Handle day selection dialog
     if (uiState.selectedDayEntries != null) {
         DayEntriesDialog(
@@ -98,103 +119,117 @@ fun AnalyticsScreen(
 }
 
 /**
- * GENERALIZATION: Show all analytics panels in a scrollable view
+ * GENERALIZATION: Show analytics panels for the selected category
  */
 @Composable
-private fun ShowAllPanels(
+private fun ShowCategoryPanels(
+    category: AnalyticsCategory,
     uiState: AnalyticsUiState,
     analyticsData: AnalyticsData,
     viewModel: AnalyticsViewModel
 ) {
-    // 1. Trends Over Time - using GenericChart
-    GenericChart(
-        title = "Trends Over Time",
-        subtitle = "Daily income and expense patterns",
-        chartType = ChartType.LINE,
-        series = AnalyticsAdapters.trendDataToChartSeries(analyticsData.trendData),
-        isLoading = analyticsData.isLoading,
-        modifier = Modifier.padding(bottom = 16.dp)
-    )
-    
-    // 2. Monthly Comparison
-    if (analyticsData.monthlyComparison != null) {
-        MonthlyComparisonCard(
-            monthlyComparison = analyticsData.monthlyComparison,
-            isLoading = analyticsData.isLoading,
-            modifier = Modifier.padding(bottom = 16.dp)
-        )
-    }
-    
-    // 3. Projection/Estimation
-    if (analyticsData.projection != null) {
-        ProjectionEstimation(
-            projectionData = analyticsData.projection,
-            isLoading = analyticsData.isLoading,
-            modifier = Modifier.padding(bottom = 16.dp)
-        )
-    }
-    
-    // 4. Top Drivers - using GenericLeaderboard
-    GenericLeaderboard(
-        title = "Top Drivers",
-        subtitle = "Leading drivers by total revenue",
-        data = AnalyticsAdapters.driverPerformanceToLeaderboard(analyticsData.driverPerformance),
-        style = LeaderboardStyle.PODIUM,
-        maxItems = 5,
-        isLoading = analyticsData.isLoading,
-        modifier = Modifier.padding(bottom = 16.dp)
-    )
-    
-    // 5. Vehicle ROI - using GenericLeaderboard
-    GenericLeaderboard(
-        title = "Vehicle ROI",
-        subtitle = "Return on investment analysis",
-        icon = Icons.Default.DirectionsCar,
-        data = AnalyticsAdapters.vehicleROIToLeaderboard(analyticsData.vehicleROI),
-        style = LeaderboardStyle.CARDS,
-        isLoading = analyticsData.isLoading,
-        modifier = Modifier.padding(bottom = 16.dp)
-    )
-    
-    // 6. Day of Week - using GenericChart
-    GenericChart(
-        title = "Weekly Patterns",
-        subtitle = "Average income by day of week",
-        chartType = ChartType.BAR_HORIZONTAL,
-        data = AnalyticsAdapters.dayOfWeekToChartData(analyticsData.dayOfWeekAnalysis),
-        isLoading = analyticsData.isLoading,
-        modifier = Modifier.padding(bottom = 16.dp)
-    )
-    
-    // 7. Expense Analysis - using GenericChart
-    GenericChart(
-        title = "Expense Breakdown",
-        subtitle = "Expenses grouped by category",
-        chartType = ChartType.PIE,
-        data = AnalyticsAdapters.expenseBreakdownToChartData(analyticsData.expenseBreakdown),
-        isLoading = analyticsData.isLoading,
-        modifier = Modifier.padding(bottom = 16.dp)
-    )
-    
-    // 8. Anomaly Detection
-    AnomalyDetection(
-        anomalies = analyticsData.anomalies,
-        isLoading = analyticsData.isLoading,
-        modifier = Modifier.padding(bottom = 16.dp)
-    )
-    
-    // 9. Calendar Overview
-    AnalyticsSection(
-        title = "Calendar Overview",
-        description = "Daily earnings visualization"
-    ) {
-        CalendarView(
-            entriesData = uiState.entriesData,
-            isLoading = uiState.isLoading,
-            onDayClick = { date, entries ->
-                viewModel.onDaySelected(date, entries)
+    when (category) {
+        AnalyticsCategory.PERFORMANCE -> {
+            GenericChart(
+                title = "Trends Over Time",
+                subtitle = "Daily income and expense patterns",
+                chartType = ChartType.LINE,
+                series = AnalyticsAdapters.trendDataToChartSeries(analyticsData.trendData),
+                isLoading = analyticsData.isLoading,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            if (analyticsData.monthlyComparison != null) {
+                MonthlyComparisonCard(
+                    monthlyComparison = analyticsData.monthlyComparison,
+                    isLoading = analyticsData.isLoading,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
             }
-        )
+
+            if (analyticsData.projection != null) {
+                ProjectionEstimation(
+                    projectionData = analyticsData.projection,
+                    isLoading = analyticsData.isLoading,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+            }
+        }
+
+        AnalyticsCategory.DRIVERS -> {
+            GenericLeaderboard(
+                title = "Top Drivers",
+                subtitle = "Leading drivers by total revenue",
+                data = AnalyticsAdapters.driverPerformanceToLeaderboard(analyticsData.driverPerformance),
+                style = LeaderboardStyle.PODIUM,
+                maxItems = 5,
+                isLoading = analyticsData.isLoading,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            DriverComparison(
+                driverPerformance = analyticsData.driverPerformance,
+                isLoading = analyticsData.isLoading
+            )
+        }
+
+        AnalyticsCategory.VEHICLES -> {
+            GenericLeaderboard(
+                title = "Vehicle ROI",
+                subtitle = "Return on investment analysis",
+                icon = Icons.Default.DirectionsCar,
+                data = AnalyticsAdapters.vehicleROIToLeaderboard(analyticsData.vehicleROI),
+                style = LeaderboardStyle.CARDS,
+                isLoading = analyticsData.isLoading,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            VehicleROIAnalysis(
+                vehicleROI = analyticsData.vehicleROI,
+                isLoading = analyticsData.isLoading
+            )
+        }
+
+        AnalyticsCategory.PATTERNS -> {
+            GenericChart(
+                title = "Weekly Patterns",
+                subtitle = "Average income by day of week",
+                chartType = ChartType.BAR_HORIZONTAL,
+                data = AnalyticsAdapters.dayOfWeekToChartData(analyticsData.dayOfWeekAnalysis),
+                isLoading = analyticsData.isLoading,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            GenericChart(
+                title = "Expense Breakdown",
+                subtitle = "Expenses grouped by category",
+                chartType = ChartType.PIE,
+                data = AnalyticsAdapters.expenseBreakdownToChartData(analyticsData.expenseBreakdown),
+                isLoading = analyticsData.isLoading,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+        }
+
+        AnalyticsCategory.INSIGHTS -> {
+            AnomalyDetection(
+                anomalies = analyticsData.anomalies,
+                isLoading = analyticsData.isLoading,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            AnalyticsSection(
+                title = "Calendar Overview",
+                description = "Daily earnings visualization"
+            ) {
+                CalendarView(
+                    entriesData = uiState.entriesData,
+                    isLoading = uiState.isLoading,
+                    onDayClick = { date, entries ->
+                        viewModel.onDaySelected(date, entries)
+                    }
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/fleetmanager/ui/screens/analytics/components/AnalyticsCategoryNavigationBar.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/analytics/components/AnalyticsCategoryNavigationBar.kt
@@ -1,0 +1,47 @@
+package com.fleetmanager.ui.screens.analytics.components
+
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.fleetmanager.ui.screens.analytics.model.AnalyticsCategory
+
+@Composable
+fun AnalyticsCategoryNavigationBar(
+    selectedCategory: AnalyticsCategory,
+    onCategorySelected: (AnalyticsCategory) -> Unit,
+    modifier: Modifier = Modifier,
+    categories: List<AnalyticsCategory> = AnalyticsCategory.values().toList()
+) {
+    NavigationBar(
+        modifier = modifier
+    ) {
+        categories.forEach { category ->
+            NavigationBarItem(
+                selected = category == selectedCategory,
+                onClick = { onCategorySelected(category) },
+                icon = {
+                    Icon(
+                        imageVector = category.icon,
+                        contentDescription = category.displayName
+                    )
+                },
+                label = {
+                    Text(
+                        text = category.displayName,
+                        style = MaterialTheme.typography.labelSmall
+                    )
+                },
+                colors = NavigationBarItemDefaults.colors(
+                    selectedIconColor = MaterialTheme.colorScheme.onPrimary,
+                    selectedTextColor = MaterialTheme.colorScheme.onPrimary,
+                    indicatorColor = MaterialTheme.colorScheme.primary
+                )
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a persistent analytics category navigation bar to provide phone-friendly access to panels
- scope the default analytics content to the active category and keep the menu tabs in sync with the bottom navigation

## Testing
- ./gradlew lint *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccf9f9b4c88323a030f86978c443c5