### PR TITLE
Improve monthly projection using weekly pattern

### DIFF
--- a/app/src/main/java/com/fleetmanager/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/analytics/AnalyticsViewModel.kt
@@ -282,7 +282,7 @@ class AnalyticsViewModel @Inject constructor(
         
         // Calculate projection using d-1 logic
         val projection = if (currentMonthEntries.isNotEmpty()) {
-            AnalyticsCalculator.calculateProjection(currentMonthEntries, yesterday)
+            AnalyticsCalculator.calculateProjection(currentMonthEntries, dayOfWeekAnalysis, yesterday)
         } else null
         
         return AnalyticsData(


### PR DESCRIPTION
## Summary
- derive day-level income totals and averages for the current month
- project the rest of the month using historical weekly day-of-week averages with sensible fallbacks
- pass the weekly pattern into the projection calculator from the analytics view model

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd369f9b2883238c826c74f4c0d98a