### PR TITLE
Fix profile background with shared container

### DIFF
--- a/app/src/main/java/com/fleetmanager/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/fleetmanager/ui/components/CommonComponents.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -20,6 +22,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -32,6 +35,27 @@ import com.fleetmanager.R
 import com.fleetmanager.ui.navigation.DashboardShortcut
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+
+@Composable
+fun FleetScreenContainer(
+    modifier: Modifier = Modifier,
+    containerColor: Color = MaterialTheme.colorScheme.background,
+    contentPadding: PaddingValues = PaddingValues(16.dp),
+    verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(16.dp),
+    content: LazyListScope.() -> Unit
+) {
+    Surface(
+        modifier = modifier.fillMaxSize(),
+        color = containerColor
+    ) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = contentPadding,
+            verticalArrangement = verticalArrangement,
+            content = content
+        )
+    }
+}
 
 // Screen Header Component with Company Logo and Profile Icon
 @Composable

--- a/app/src/main/java/com/fleetmanager/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/profile/ProfileScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -19,7 +18,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -28,6 +26,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.fleetmanager.domain.model.UserRole
+import com.fleetmanager.ui.components.FleetScreenContainer
 import com.fleetmanager.ui.components.StatusCard
 import com.fleetmanager.ui.components.StatusType
 
@@ -37,19 +36,14 @@ fun ProfileScreen(
     viewModel: ProfileViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    val context = LocalContext.current
-    
     // Image picker launcher
     val imagePickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
     ) { uri ->
         uri?.let { viewModel.updateProfilePicture(it) }
     }
-    
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
+
+    FleetScreenContainer(
         verticalArrangement = Arrangement.spacedBy(24.dp)
     ) {
         // Header with back button

--- a/app/src/main/java/com/fleetmanager/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/settings/SettingsScreen.kt
@@ -1,7 +1,6 @@
 package com.fleetmanager.ui.screens.settings
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.BugReport
@@ -48,12 +47,7 @@ fun SettingsScreen(
         onError = { error -> viewModel.setError(error) }
     )
 
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
+    FleetScreenContainer {
         item {
             ScreenHeader(
                 title = "Settings",


### PR DESCRIPTION
## Summary
- add a reusable FleetScreenContainer composable that applies the app surface color and default padding
- update the profile and settings screens to use the shared container so the profile screen no longer renders on a white background

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5a9e98e88323b2afc009d7ce5ac2