### PR TITLE
refactor: replace purple palette with professional blues

### DIFF
--- a/app/src/main/java/com/fleetmanager/ui/model/ChartData.kt
+++ b/app/src/main/java/com/fleetmanager/ui/model/ChartData.kt
@@ -1,6 +1,8 @@
 package com.fleetmanager.ui.model
 
 import androidx.compose.ui.graphics.Color
+import com.fleetmanager.ui.theme.AccentNavy
+import com.fleetmanager.ui.theme.PrimaryBlue80
 import java.util.*
 
 /**
@@ -134,13 +136,13 @@ object ChartDataGenerator {
     
     private fun getColorForIndex(index: Int): Color {
         val colors = listOf(
-            Color(0xFF6750A4), // Material Purple
+            PrimaryBlue80, // Corporate Blue
             Color(0xFF1976D2), // Material Blue
             Color(0xFF388E3C), // Material Green
             Color(0xFFFF8F00), // Material Amber
             Color(0xFFD32F2F), // Material Red
             Color(0xFF0097A7), // Material Cyan
-            Color(0xFF7B1FA2), // Material Deep Purple
+            AccentNavy, // Corporate Navy
             Color(0xFF5D4037), // Material Brown
             Color(0xFFC2185B), // Material Pink
             Color(0xFF689F38), // Material Light Green

--- a/app/src/main/java/com/fleetmanager/ui/screens/analytics/components/AnomalyDetection.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/analytics/components/AnomalyDetection.kt
@@ -7,11 +7,11 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Warning
-import androidx.compose.material.icons.filled.TrendingDown
-import androidx.compose.material.icons.filled.TrendingUp
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.TrendingDown
+import androidx.compose.material.icons.filled.TrendingUp
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -24,6 +24,7 @@ import com.fleetmanager.ui.screens.analytics.model.AnomalyData
 import com.fleetmanager.ui.screens.analytics.model.AnomalyType
 import com.fleetmanager.ui.screens.analytics.utils.AnalyticsCalculator
 import com.fleetmanager.ui.screens.analytics.utils.AnalyticsUtils
+import com.fleetmanager.ui.theme.AccentNavy
 import java.time.format.DateTimeFormatter
 
 /**
@@ -165,7 +166,7 @@ private fun AnomalySummary(anomalies: List<AnomalyData>) {
                 AnomalyStat(
                     label = "Zero Income",
                     count = anomalyCounts[AnomalyType.ZERO_INCOME] ?: 0,
-                    color = Color(0xFF9C27B0)
+                    color = AccentNavy
                 )
                 AnomalyStat(
                     label = "Other",
@@ -397,7 +398,7 @@ private fun getAnomalyIconAndColor(type: AnomalyType): Pair<ImageVector, Color> 
     return when (type) {
         AnomalyType.LOW_INCOME -> Icons.Default.TrendingDown to Color(0xFFF44336)
         AnomalyType.HIGH_EXPENSES -> Icons.Default.TrendingUp to Color(0xFFFF9800)
-        AnomalyType.ZERO_INCOME -> Icons.Default.Error to Color(0xFF9C27B0)
+        AnomalyType.ZERO_INCOME -> Icons.Default.Error to AccentNavy
         AnomalyType.UNUSUAL_PATTERN -> Icons.Default.Warning to Color(0xFF607D8B)
     }
 }

--- a/app/src/main/java/com/fleetmanager/ui/screens/analytics/utils/AnalyticsUtils.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/analytics/utils/AnalyticsUtils.kt
@@ -3,6 +3,7 @@ package com.fleetmanager.ui.screens.analytics.utils
 import androidx.compose.ui.graphics.Color
 import com.fleetmanager.domain.model.ExpenseType
 import com.fleetmanager.ui.screens.analytics.model.AnomalyType
+import com.fleetmanager.ui.theme.AccentNavy
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.ZoneId
@@ -103,7 +104,7 @@ object AnalyticsUtils {
             ExpenseType.CAR_WASH -> Color(0xFF00BCD4) // Cyan
             ExpenseType.FINE -> Colors.ERROR // Red
             ExpenseType.MAINTENANCE -> Colors.WARNING // Orange
-            ExpenseType.OTHER -> Color(0xFF9C27B0) // Purple
+            ExpenseType.OTHER -> AccentNavy // Professional accent blue
         }
     }
     
@@ -115,7 +116,7 @@ object AnalyticsUtils {
         return when (type) {
             AnomalyType.LOW_INCOME -> Colors.ERROR
             AnomalyType.HIGH_EXPENSES -> Colors.WARNING
-            AnomalyType.ZERO_INCOME -> Color(0xFF9C27B0) // Purple
+            AnomalyType.ZERO_INCOME -> AccentNavy // Professional accent blue
             AnomalyType.UNUSUAL_PATTERN -> Colors.NEUTRAL
         }
     }
@@ -143,7 +144,7 @@ object AnalyticsUtils {
             DayOfWeek.MONDAY -> Colors.INFO
             DayOfWeek.TUESDAY -> Colors.SUCCESS
             DayOfWeek.WEDNESDAY -> Colors.WARNING
-            DayOfWeek.THURSDAY -> Color(0xFF9C27B0) // Purple
+            DayOfWeek.THURSDAY -> AccentNavy // Professional accent blue
             DayOfWeek.FRIDAY -> Colors.ERROR
             DayOfWeek.SATURDAY -> Colors.NEUTRAL
             DayOfWeek.SUNDAY -> Color(0xFF795548) // Brown

--- a/app/src/main/java/com/fleetmanager/ui/theme/Color.kt
+++ b/app/src/main/java/com/fleetmanager/ui/theme/Color.kt
@@ -2,13 +2,15 @@ package com.fleetmanager.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+val PrimaryBlue80 = Color(0xFF4D9DE0)
+val SecondarySlate80 = Color(0xFFA6B1C3)
+val AccentTeal80 = Color(0xFF40C4A3)
 
-val Purple40 = Color(0xFF6650A4)
-val PurpleGrey40 = Color(0xFF625B71)
-val Pink40 = Color(0xFF7D5260)
+val PrimaryBlue40 = Color(0xFF1B3A63)
+val SecondarySlate40 = Color(0xFF2D3545)
+val AccentTeal40 = Color(0xFF146354)
+
+val AccentNavy = Color(0xFF1B4F72)
 
 val AppBackgroundBlack = Color(0xFF08080B)
 val AppSurfaceDark = Color(0xFF111116)

--- a/app/src/main/java/com/fleetmanager/ui/theme/Theme.kt
+++ b/app/src/main/java/com/fleetmanager/ui/theme/Theme.kt
@@ -20,18 +20,18 @@ import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    onPrimary = Color(0xFF2B1947),
-    primaryContainer = Color(0xFF4A3A7A),
-    onPrimaryContainer = Color(0xFFF3E3FF),
-    secondary = PurpleGrey80,
-    onSecondary = Color(0xFF1F1A2B),
-    secondaryContainer = Color(0xFF383248),
-    onSecondaryContainer = Color(0xFFE8DEF8),
-    tertiary = Pink80,
-    onTertiary = Color(0xFF420016),
-    tertiaryContainer = Color(0xFF65112F),
-    onTertiaryContainer = Color(0xFFFFD9E0),
+    primary = PrimaryBlue80,
+    onPrimary = Color(0xFF071425),
+    primaryContainer = AccentNavy,
+    onPrimaryContainer = Color(0xFFD9E7F8),
+    secondary = SecondarySlate80,
+    onSecondary = Color(0xFF0D141C),
+    secondaryContainer = SecondarySlate40,
+    onSecondaryContainer = Color(0xFFE2E6EB),
+    tertiary = AccentTeal80,
+    onTertiary = Color(0xFF00221B),
+    tertiaryContainer = AccentTeal40,
+    onTertiaryContainer = Color(0xFFD1F5EB),
     background = AppBackgroundBlack,
     onBackground = AppOnBackgroundDark,
     surface = AppSurfaceDark,
@@ -41,22 +41,22 @@ private val DarkColorScheme = darkColorScheme(
     outline = AppOutlineDark,
     inverseSurface = AppOnSurfaceDark,
     inverseOnSurface = AppSurfaceDark,
-    inversePrimary = Purple40
+    inversePrimary = PrimaryBlue40
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
+    primary = PrimaryBlue40,
     onPrimary = Color.White,
-    primaryContainer = Purple80,
-    onPrimaryContainer = Color(0xFF1F1147),
-    secondary = PurpleGrey40,
+    primaryContainer = PrimaryBlue80,
+    onPrimaryContainer = Color(0xFF04142A),
+    secondary = SecondarySlate40,
     onSecondary = Color.White,
-    secondaryContainer = PurpleGrey80,
-    onSecondaryContainer = Color(0xFF201B2C),
-    tertiary = Pink40,
+    secondaryContainer = SecondarySlate80,
+    onSecondaryContainer = Color(0xFF1A232E),
+    tertiary = AccentTeal40,
     onTertiary = Color.White,
-    tertiaryContainer = Pink80,
-    onTertiaryContainer = Color(0xFF3D001A),
+    tertiaryContainer = AccentTeal80,
+    onTertiaryContainer = Color(0xFF0A2F29),
     background = AppBackgroundBlack,
     onBackground = AppOnBackgroundDark,
     surface = AppSurfaceDark,
@@ -66,7 +66,7 @@ private val LightColorScheme = lightColorScheme(
     outline = AppOutlineDark,
     inverseSurface = AppOnSurfaceDark,
     inverseOnSurface = AppSurfaceDark,
-    inversePrimary = Purple80
+    inversePrimary = PrimaryBlue80
 )
 
 private fun enforceBackgroundPalette(colorScheme: ColorScheme): ColorScheme {


### PR DESCRIPTION
## Summary
- introduce a blue-focused corporate palette and update the Material color schemes
- refresh analytics chart and anomaly visuals to use the new professional accent colors
- centralize accent blue usage for zero-income and other analytics contexts

## Testing
- ./gradlew test *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf043438388323ad0401ad4857606e