### PR TITLE
Update driver and vehicle admin forms for new data model

### DIFF
--- a/app/src/main/java/com/fleetmanager/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/settings/SettingsScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp

--- a/app/src/main/java/com/fleetmanager/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/settings/SettingsScreen.kt
@@ -407,7 +407,7 @@ private fun AddDriverDialog(
                         )
                     }
                     Switch(checked = isActive, onCheckedChange = { isActive = it })
-                )
+                }
             }
         },
         confirmButton = {


### PR DESCRIPTION
## Summary
- extend the admin driver dialog to capture full driver profile data, including salary and annual costs
- expand the admin vehicle dialog to gather pricing, financing, and operational details required by the new vehicle model
- update settings view model to persist drivers and vehicles through the domain save use cases with new success and error messaging

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d13a42ab788323a2f17edafb82cba9