### PR TITLE
Enable history filtering and entry bulk editing

### DIFF
--- a/app/src/main/java/com/fleetmanager/data/remote/FirestoreService.kt
+++ b/app/src/main/java/com/fleetmanager/data/remote/FirestoreService.kt
@@ -137,11 +137,12 @@ class FirestoreService @Inject constructor(
     
     // Daily Entries
     suspend fun saveDailyEntry(entry: DailyEntry) {
-        val userId = requireAuth()
-        Log.d(TAG, "Saving daily entry to Firestore for user $userId: ${entry.id}")
+        val currentUserId = requireAuth()
+        val targetUserId = entry.userId.takeIf { it.isNotBlank() } ?: currentUserId
+        Log.d(TAG, "Saving daily entry to Firestore for user $targetUserId: ${entry.id}")
         try {
             // Add userId field to the entry
-            val entryWithUserId = entry.copy(userId = userId)
+            val entryWithUserId = entry.copy(userId = targetUserId)
             getCollection("entries")
                 .document(entry.id)
                 .set(entryWithUserId)
@@ -386,11 +387,12 @@ class FirestoreService @Inject constructor(
      *    }
      */
     suspend fun saveExpense(expense: Expense) {
-        val userId = requireAuth()
-        Log.d(TAG, "Saving expense to Firestore for user $userId: ${expense.id}")
+        val currentUserId = requireAuth()
+        val targetUserId = expense.userId.takeIf { it.isNotBlank() } ?: currentUserId
+        Log.d(TAG, "Saving expense to Firestore for user $targetUserId: ${expense.id}")
         try {
             // Add userId field to the expense
-            val expenseWithUserId = expense.copy(userId = userId)
+            val expenseWithUserId = expense.copy(userId = targetUserId)
             getCollection("expenses")
                 .document(expense.id)
                 .set(expenseWithUserId)

--- a/app/src/main/java/com/fleetmanager/data/repository/FleetRepositoryImpl.kt
+++ b/app/src/main/java/com/fleetmanager/data/repository/FleetRepositoryImpl.kt
@@ -88,28 +88,29 @@ class FleetRepositoryImpl @Inject constructor(
     
     override suspend fun saveDailyEntry(entry: DailyEntry, photoUri: Uri?, photoUris: List<Uri>) {
         val userId = authService.getCurrentUserId() ?: ""
+        val existingOwnerId = entry.userId.takeIf { it.isNotBlank() } ?: userId
         val entryToSave = when {
             photoUris.isNotEmpty() -> {
                 try {
                     val photoUrls = photoUris.map { uri ->
                         storageService.uploadPhoto(uri, "${entry.id}_${System.currentTimeMillis()}")
                     }
-                    entry.copy(userId = userId, photoUrls = photoUrls, isSynced = true)
+                    entry.copy(userId = existingOwnerId, photoUrls = photoUrls, isSynced = true)
                 } catch (e: Exception) {
                     // Save locally if upload fails
-                    entry.copy(userId = userId, isSynced = false)
+                    entry.copy(userId = existingOwnerId, isSynced = false)
                 }
             }
             photoUri != null -> {
                 try {
                     val photoUrls = listOf(storageService.uploadPhoto(photoUri, entry.id))
-                    entry.copy(userId = userId, photoUrls = photoUrls, isSynced = true)
+                    entry.copy(userId = existingOwnerId, photoUrls = photoUrls, isSynced = true)
                 } catch (e: Exception) {
                     // Save locally if upload fails
-                    entry.copy(userId = userId, isSynced = false)
+                    entry.copy(userId = existingOwnerId, isSynced = false)
                 }
             }
-            else -> entry.copy(userId = userId)
+            else -> entry.copy(userId = existingOwnerId)
         }
         
         // Always save locally first
@@ -248,28 +249,29 @@ class FleetRepositoryImpl @Inject constructor(
     
     override suspend fun saveExpense(expense: Expense, photoUri: Uri?, photoUris: List<Uri>) {
         val userId = authService.getCurrentUserId() ?: ""
+        val existingOwnerId = expense.userId.takeIf { it.isNotBlank() } ?: userId
         val expenseToSave = when {
             photoUris.isNotEmpty() -> {
                 try {
                     val photoUrls = photoUris.map { uri ->
                         storageService.uploadPhoto(uri, "${expense.id}_${System.currentTimeMillis()}")
                     }
-                    expense.copy(userId = userId, photoUrls = photoUrls, isSynced = true)
+                    expense.copy(userId = existingOwnerId, photoUrls = photoUrls, isSynced = true)
                 } catch (e: Exception) {
                     // Save locally if upload fails
-                    expense.copy(userId = userId, isSynced = false)
+                    expense.copy(userId = existingOwnerId, isSynced = false)
                 }
             }
             photoUri != null -> {
                 try {
                     val photoUrls = listOf(storageService.uploadPhoto(photoUri, expense.id))
-                    expense.copy(userId = userId, photoUrls = photoUrls, isSynced = true)
+                    expense.copy(userId = existingOwnerId, photoUrls = photoUrls, isSynced = true)
                 } catch (e: Exception) {
                     // Save locally if upload fails
-                    expense.copy(userId = userId, isSynced = false)
+                    expense.copy(userId = existingOwnerId, isSynced = false)
                 }
             }
-            else -> expense.copy(userId = userId)
+            else -> expense.copy(userId = existingOwnerId)
         }
         
         // Always save locally first

--- a/app/src/main/java/com/fleetmanager/domain/usecase/GetExpenseByIdUseCase.kt
+++ b/app/src/main/java/com/fleetmanager/domain/usecase/GetExpenseByIdUseCase.kt
@@ -1,0 +1,15 @@
+package com.fleetmanager.domain.usecase
+
+import com.fleetmanager.domain.model.Expense
+import com.fleetmanager.domain.repository.FleetRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetExpenseByIdUseCase @Inject constructor(
+    private val repository: FleetRepository
+) {
+    operator fun invoke(expenseId: String): Flow<Expense?> {
+        require(expenseId.isNotBlank()) { "Expense ID cannot be blank" }
+        return repository.getExpenseById(expenseId)
+    }
+}

--- a/app/src/main/java/com/fleetmanager/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/fleetmanager/ui/components/CommonComponents.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Sync
@@ -511,34 +512,62 @@ fun DailyEntryTile(
     entry: com.fleetmanager.domain.model.DailyEntry,
     onClick: () -> Unit,
     onDelete: (() -> Unit)? = null,
-    showDeleteButton: Boolean = false
+    showDeleteButton: Boolean = false,
+    showEditButton: Boolean = false,
+    onEdit: (() -> Unit)? = null,
+    selectionMode: Boolean = false,
+    isSelected: Boolean = false,
+    onSelectionChange: (() -> Unit)? = null
 ) {
     val dateFormatter = java.text.SimpleDateFormat("MMM dd, yyyy", java.util.Locale.getDefault())
-    
-    ListItemCard(onClick = onClick) {
+
+    ListItemCard(
+        onClick = {
+            if (selectionMode) {
+                onSelectionChange?.invoke()
+            } else {
+                onClick()
+            }
+        }
+    ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.Top
         ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = entry.driverName,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold
-                )
-                Text(
-                    text = entry.vehicle,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Text(
-                    text = dateFormatter.format(entry.date),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+            Row(
+                modifier = Modifier.weight(1f),
+                verticalAlignment = Alignment.Top
+            ) {
+                if (selectionMode) {
+                    Checkbox(
+                        checked = isSelected,
+                        onCheckedChange = { onSelectionChange?.invoke() },
+                        modifier = Modifier
+                            .padding(end = 12.dp)
+                            .align(Alignment.Top)
+                    )
+                }
+
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = entry.driverName,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = entry.vehicle,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = dateFormatter.format(entry.date),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
-            
+
             Column(horizontalAlignment = Alignment.End) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
@@ -559,9 +588,22 @@ fun DailyEntryTile(
                             )
                         }
                     }
-                    
-                    // Delete button for admin users
-                    if (showDeleteButton && onDelete != null) {
+
+                    if (showEditButton && onEdit != null && !selectionMode) {
+                        IconButton(
+                            onClick = onEdit,
+                            modifier = Modifier.size(24.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Edit,
+                                contentDescription = "Edit entry",
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(20.dp)
+                            )
+                        }
+                    }
+
+                    if (showDeleteButton && onDelete != null && !selectionMode) {
                         IconButton(
                             onClick = { onDelete() },
                             modifier = Modifier.size(24.dp)
@@ -577,7 +619,7 @@ fun DailyEntryTile(
                 }
             }
         }
-        
+
         if (entry.notes.isNotEmpty()) {
             Spacer(modifier = Modifier.height(8.dp))
             Text(
@@ -586,9 +628,9 @@ fun DailyEntryTile(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
-        
+
         Spacer(modifier = Modifier.height(8.dp))
-        
+
         EarningsChips(
             earnings = listOf(
                 com.fleetmanager.ui.components.EarningItem("Uber", entry.uberEarnings),

--- a/app/src/main/java/com/fleetmanager/ui/navigation/FleetNavigation.kt
+++ b/app/src/main/java/com/fleetmanager/ui/navigation/FleetNavigation.kt
@@ -49,6 +49,12 @@ sealed class Screen(val route: String) {
     object EntryDetail : Screen("entry_detail/{entryId}") {
         fun createRoute(entryId: String) = "entry_detail/$entryId"
     }
+    object EditEntry : Screen("edit_entry/{entryId}") {
+        fun createRoute(entryId: String) = "edit_entry/$entryId"
+    }
+    object EditExpense : Screen("edit_expense/{expenseId}") {
+        fun createRoute(expenseId: String) = "edit_expense/$expenseId"
+    }
 }
 
 /**
@@ -132,7 +138,9 @@ private fun MainNavigation(
                 onAddEntryClick = { navController.navigate(Screen.AddEntry.route) },
                 onAddExpenseClick = { navController.navigate(Screen.AddExpense.route) },
                 onNavigateToProfile = { navController.navigate(Screen.Profile.route) },
-                onEntryClick = { entryId -> navController.navigate(Screen.EntryDetail.createRoute(entryId)) }
+                onEntryClick = { entryId -> navController.navigate(Screen.EntryDetail.createRoute(entryId)) },
+                onEditEntry = { entryId -> navController.navigate(Screen.EditEntry.createRoute(entryId)) },
+                onEditExpense = { expenseId -> navController.navigate(Screen.EditExpense.createRoute(expenseId)) }
             )
         }
         
@@ -162,6 +170,29 @@ private fun MainNavigation(
             val entryId = backStackEntry.arguments?.getString("entryId") ?: ""
             EntryDetailScreen(
                 entryId = entryId,
+                onNavigateBack = { navController.popBackStack() },
+                onEditEntry = { navController.navigate(Screen.EditEntry.createRoute(entryId)) }
+            )
+        }
+
+        composable(
+            route = Screen.EditEntry.route,
+            arguments = listOf(navArgument("entryId") { type = NavType.StringType })
+        ) { backStackEntry ->
+            val entryId = backStackEntry.arguments?.getString("entryId") ?: ""
+            AddEntryScreen(
+                entryId = entryId,
+                onNavigateBack = { navController.popBackStack() }
+            )
+        }
+
+        composable(
+            route = Screen.EditExpense.route,
+            arguments = listOf(navArgument("expenseId") { type = NavType.StringType })
+        ) { backStackEntry ->
+            val expenseId = backStackEntry.arguments?.getString("expenseId") ?: ""
+            NewExpenseEntryScreen(
+                expenseId = expenseId,
                 onNavigateBack = { navController.popBackStack() }
             )
         }

--- a/app/src/main/java/com/fleetmanager/ui/navigation/MainScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/navigation/MainScreen.kt
@@ -34,7 +34,9 @@ fun MainScreen(
     onAddEntryClick: () -> Unit,
     onAddExpenseClick: () -> Unit,
     onNavigateToProfile: () -> Unit,
-    onEntryClick: (String) -> Unit
+    onEntryClick: (String) -> Unit,
+    onEditEntry: (String) -> Unit,
+    onEditExpense: (String) -> Unit
 ) {
     val currentIndex by NavigationState.currentPageIndex.collectAsState()
 
@@ -106,6 +108,8 @@ fun MainScreen(
                         onAddEntryClick = onAddEntryClick,
                         onAddExpenseClick = onAddExpenseClick,
                         onEntryClick = onEntryClick,
+                        onEditEntry = onEditEntry,
+                        onEditExpense = onEditExpense,
                         onNavigateToProfile = onNavigateToProfile
                     )
                     Screen.Analytics -> AnalyticsScreen(

--- a/app/src/main/java/com/fleetmanager/ui/screens/entry/EntryListScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/entry/EntryListScreen.kt
@@ -1,26 +1,34 @@
 package com.fleetmanager.ui.screens.entry
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Assignment
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.*
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.fleetmanager.ui.viewmodel.EntryListViewModel
 import com.fleetmanager.domain.model.DailyEntry
+import com.fleetmanager.domain.model.Expense
 import com.fleetmanager.domain.model.UserRole
 import com.fleetmanager.domain.model.PermissionManager
 import com.fleetmanager.ui.components.*
 import com.fleetmanager.ui.utils.collectAsStateWithLifecycle
 import com.fleetmanager.ui.utils.rememberStableLambda0
 import com.fleetmanager.ui.utils.rememberStableLambda1
+import com.fleetmanager.data.dto.UserDto
+import com.fleetmanager.domain.model.Vehicle
+import com.fleetmanager.ui.viewmodel.HistoryFilter
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -29,6 +37,8 @@ fun EntryListScreen(
     onAddEntryClick: () -> Unit,
     onAddExpenseClick: () -> Unit,
     onEntryClick: (String) -> Unit,
+    onEditEntry: (String) -> Unit,
+    onEditExpense: (String) -> Unit,
     onNavigateToProfile: (() -> Unit)? = null,
     viewModel: EntryListViewModel = hiltViewModel()
 ) {
@@ -44,6 +54,24 @@ fun EntryListScreen(
     val onAddClick: () -> Unit = rememberStableLambda0({ onAddEntryClick() })
     val onExpenseClick: () -> Unit = rememberStableLambda0({ onAddExpenseClick() })
     
+    val context = LocalContext.current
+
+    LaunchedEffect(uiState.bulkEditMessage) {
+        uiState.bulkEditMessage?.let { message ->
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+            viewModel.clearBulkEditMessage()
+        }
+    }
+
+    LaunchedEffect(uiState.bulkEditError) {
+        uiState.bulkEditError?.let { error ->
+            Toast.makeText(context, error, Toast.LENGTH_LONG).show()
+            viewModel.clearBulkEditError()
+        }
+    }
+
+    var showBulkEditDialog by remember { mutableStateOf(false) }
+
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
             modifier = Modifier
@@ -78,7 +106,36 @@ fun EntryListScreen(
                 }
             }
         }
-        
+
+        if (PermissionManager.canEdit(userRole)) {
+            item {
+                HistoryFilterRow(
+                    selectedFilter = uiState.filter,
+                    onFilterSelected = viewModel::updateFilter
+                )
+            }
+        }
+
+        if (PermissionManager.canEdit(userRole) && uiState.filter == HistoryFilter.INCOME) {
+            item {
+                if (uiState.isSelectionMode) {
+                    BulkEditSelectionBar(
+                        selectedCount = uiState.selectedEntryIds.size,
+                        totalCount = uiState.entries.size,
+                        onApply = { showBulkEditDialog = true },
+                        onCancel = viewModel::cancelBulkEdit,
+                        onSelectAll = viewModel::selectAllEntries,
+                        isApplying = uiState.isBulkEditing
+                    )
+                } else {
+                    BulkEditStartBar(
+                        onStart = viewModel::startBulkEdit,
+                        enabled = uiState.entries.isNotEmpty()
+                    )
+                }
+            }
+        }
+
         when {
             uiState.isLoading -> {
                 item {
@@ -91,7 +148,7 @@ fun EntryListScreen(
                 }
             }
             
-            uiState.entries.isEmpty() -> {
+            uiState.filter == HistoryFilter.INCOME && uiState.entries.isEmpty() -> {
                 item {
                     EmptyState(
                         icon = Icons.Default.Assignment,
@@ -100,41 +157,81 @@ fun EntryListScreen(
                     )
                 }
             }
-            
-            else -> {
-                items(
-                    items = uiState.entries,
-                    key = { it.id }
-                ) { entry ->
-                    DailyEntryTile(
-                        entry = entry,
-                        onClick = { onEntryClick(entry.id) },
-                        onDelete = {
-                            entryToDelete = entry
-                            showDeleteDialog = true
-                        },
-                        showDeleteButton = PermissionManager.canDelete(userRole)
+
+            uiState.filter == HistoryFilter.EXPENSE && uiState.expenses.isEmpty() -> {
+                item {
+                    EmptyState(
+                        icon = Icons.Default.Assignment,
+                        title = "No expenses yet",
+                        description = "Record an expense to see it here"
                     )
+                }
+            }
+
+            else -> {
+                when (uiState.filter) {
+                    HistoryFilter.INCOME -> {
+                        items(
+                            items = uiState.entries,
+                            key = { it.id }
+                        ) { entry ->
+                            DailyEntryTile(
+                                entry = entry,
+                                onClick = {
+                                    if (uiState.isSelectionMode) {
+                                        viewModel.toggleEntrySelection(entry.id)
+                                    } else {
+                                        onEntryClick(entry.id)
+                                    }
+                                },
+                                onDelete = {
+                                    entryToDelete = entry
+                                    showDeleteDialog = true
+                                },
+                                showDeleteButton = PermissionManager.canDelete(userRole),
+                                showEditButton = PermissionManager.canEdit(userRole),
+                                onEdit = { onEditEntry(entry.id) },
+                                selectionMode = uiState.isSelectionMode,
+                                isSelected = uiState.selectedEntryIds.contains(entry.id),
+                                onSelectionChange = { viewModel.toggleEntrySelection(entry.id) }
+                            )
+                        }
+                    }
+                    HistoryFilter.EXPENSE -> {
+                        items(
+                            items = uiState.expenses,
+                            key = { it.id }
+                        ) { expense ->
+                            ExpenseListItem(
+                                expense = expense,
+                                onClick = { onEditExpense(expense.id) },
+                                showEditButton = PermissionManager.canEdit(userRole),
+                                onEdit = { onEditExpense(expense.id) }
+                            )
+                        }
+                    }
                 }
             }
         }
     }
-        
+
         // Floating Action Button Menu - all roles can create
-        FloatingActionButtonMenu(
-            items = createDefaultFabMenuItems(
-                onIncomeClick = onAddClick,
-                onExpenseClick = onExpenseClick
-            ),
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(16.dp)
-        )
-        
+        if (!uiState.isSelectionMode) {
+            FloatingActionButtonMenu(
+                items = createDefaultFabMenuItems(
+                    onIncomeClick = onAddClick,
+                    onExpenseClick = onExpenseClick
+                ),
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp)
+            )
+        }
+
         // Delete confirmation dialog
         if (showDeleteDialog && entryToDelete != null) {
             AlertDialog(
-                onDismissRequest = { 
+                onDismissRequest = {
                     showDeleteDialog = false
                     entryToDelete = null
                 },
@@ -168,6 +265,327 @@ fun EntryListScreen(
                     }
                 }
             )
+        }
+
+        if (showBulkEditDialog) {
+            BulkEditDialog(
+                driverOptions = uiState.driverUsers,
+                vehicleOptions = uiState.vehicles,
+                isProcessing = uiState.isBulkEditing,
+                onDismiss = {
+                    showBulkEditDialog = false
+                    if (uiState.selectedEntryIds.isEmpty()) {
+                        viewModel.cancelBulkEdit()
+                    }
+                },
+                onConfirm = { driverId, vehicleId ->
+                    viewModel.bulkUpdateSelectedEntries(driverId, vehicleId)
+                    showBulkEditDialog = false
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun HistoryFilterRow(
+    selectedFilter: HistoryFilter,
+    onFilterSelected: (HistoryFilter) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "Show",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.weight(1f)
+        )
+        FilterChip(
+            selected = selectedFilter == HistoryFilter.INCOME,
+            onClick = { onFilterSelected(HistoryFilter.INCOME) },
+            label = { Text("Income") }
+        )
+        FilterChip(
+            selected = selectedFilter == HistoryFilter.EXPENSE,
+            onClick = { onFilterSelected(HistoryFilter.EXPENSE) },
+            label = { Text("Expenses") }
+        )
+    }
+}
+
+@Composable
+private fun BulkEditStartBar(
+    onStart: () -> Unit,
+    enabled: Boolean
+) {
+    OutlinedCard(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Bulk edit",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Text(
+                    text = "Assign drivers and vehicles to multiple entries at once.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Button(
+                onClick = onStart,
+                enabled = enabled
+            ) {
+                Icon(imageVector = Icons.Default.Edit, contentDescription = null)
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Start")
+            }
+        }
+    }
+}
+
+@Composable
+private fun BulkEditSelectionBar(
+    selectedCount: Int,
+    totalCount: Int,
+    onApply: () -> Unit,
+    onCancel: () -> Unit,
+    onSelectAll: () -> Unit,
+    isApplying: Boolean
+) {
+    OutlinedCard(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.outlinedCardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = "Selected $selectedCount of $totalCount entries",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                OutlinedButton(onClick = onSelectAll, enabled = totalCount > 0) {
+                    Text("Select all")
+                }
+                OutlinedButton(onClick = onCancel) {
+                    Text("Cancel")
+                }
+                Button(
+                    onClick = onApply,
+                    enabled = selectedCount > 0 && !isApplying
+                ) {
+                    if (isApplying) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(18.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.onPrimary
+                        )
+                    } else {
+                        Text("Update")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BulkEditDialog(
+    driverOptions: List<UserDto>,
+    vehicleOptions: List<Vehicle>,
+    isProcessing: Boolean,
+    onDismiss: () -> Unit,
+    onConfirm: (String, String) -> Unit
+) {
+    var selectedDriverId by remember(driverOptions) {
+        mutableStateOf(driverOptions.firstOrNull()?.id.orEmpty())
+    }
+    var selectedVehicleId by remember(vehicleOptions) {
+        mutableStateOf(vehicleOptions.firstOrNull()?.id.orEmpty())
+    }
+    var driverExpanded by remember { mutableStateOf(false) }
+    var vehicleExpanded by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Bulk edit entries") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                ExposedDropdownMenuBox(
+                    expanded = driverExpanded,
+                    onExpandedChange = { driverExpanded = it }
+                ) {
+                    OutlinedTextField(
+                        value = driverOptions.firstOrNull { it.id == selectedDriverId }?.name ?: "",
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text("Driver") },
+                        trailingIcon = {
+                            ExposedDropdownMenuDefaults.TrailingIcon(expanded = driverExpanded)
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .menuAnchor()
+                    )
+                    ExposedDropdownMenu(
+                        expanded = driverExpanded,
+                        onDismissRequest = { driverExpanded = false }
+                    ) {
+                        if (driverOptions.isEmpty()) {
+                            DropdownMenuItem(
+                                text = { Text("No drivers available") },
+                                onClick = { }
+                            )
+                        } else {
+                            driverOptions.forEach { driver ->
+                                DropdownMenuItem(
+                                    text = { Text(driver.name) },
+                                    onClick = {
+                                        selectedDriverId = driver.id
+                                        driverExpanded = false
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+
+                ExposedDropdownMenuBox(
+                    expanded = vehicleExpanded,
+                    onExpandedChange = { vehicleExpanded = it }
+                ) {
+                    OutlinedTextField(
+                        value = vehicleOptions.firstOrNull { it.id == selectedVehicleId }?.displayName ?: "",
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text("Vehicle") },
+                        trailingIcon = {
+                            ExposedDropdownMenuDefaults.TrailingIcon(expanded = vehicleExpanded)
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .menuAnchor()
+                    )
+                    ExposedDropdownMenu(
+                        expanded = vehicleExpanded,
+                        onDismissRequest = { vehicleExpanded = false }
+                    ) {
+                        if (vehicleOptions.isEmpty()) {
+                            DropdownMenuItem(
+                                text = { Text("No vehicles available") },
+                                onClick = { }
+                            )
+                        } else {
+                            vehicleOptions.forEach { vehicle ->
+                                DropdownMenuItem(
+                                    text = { Text(vehicle.displayName) },
+                                    onClick = {
+                                        selectedVehicleId = vehicle.id
+                                        vehicleExpanded = false
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirm(selectedDriverId, selectedVehicleId) },
+                enabled = driverOptions.isNotEmpty() && vehicleOptions.isNotEmpty() && !isProcessing
+            ) {
+                if (isProcessing) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Text("Apply")
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !isProcessing) {
+                Text("Cancel")
+            }
+        }
+    )
+}
+
+@Composable
+private fun ExpenseListItem(
+    expense: Expense,
+    onClick: () -> Unit,
+    showEditButton: Boolean,
+    onEdit: () -> Unit
+) {
+    val dateFormatter = remember { SimpleDateFormat("MMM dd, yyyy", Locale.getDefault()) }
+    val itemClick: () -> Unit = if (showEditButton) onClick else {}
+    ListItemCard(onClick = itemClick) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.Top
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = expense.driverName,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    text = expense.vehicle,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = dateFormatter.format(expense.date),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = "-$${String.format("%.2f", expense.amount)}",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.error
+                )
+                if (expense.notes.isNotEmpty()) {
+                    Text(
+                        text = expense.notes,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 8.dp)
+                    )
+                }
+                if (showEditButton) {
+                    IconButton(onClick = onEdit) {
+                        Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit expense")
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/fleetmanager/ui/screens/entry/NewExpenseEntryScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/entry/NewExpenseEntryScreen.kt
@@ -36,6 +36,7 @@ import java.util.*
 @Composable
 fun NewExpenseEntryScreen(
     onNavigateBack: () -> Unit,
+    expenseId: String? = null,
     viewModel: AddExpenseViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -49,6 +50,12 @@ fun NewExpenseEntryScreen(
         }
     }
     
+    LaunchedEffect(expenseId) {
+        if (!expenseId.isNullOrBlank()) {
+            viewModel.loadExpenseForEdit(expenseId)
+        }
+    }
+
     LaunchedEffect(uiState.isSaved) {
         if (uiState.isSaved) {
             onNavigateBack()
@@ -58,7 +65,7 @@ fun NewExpenseEntryScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Add Expense") },
+                title = { Text(if (uiState.isEditing) "Edit Expense" else "Add Expense") },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(Icons.Default.ArrowBack, contentDescription = "Back")
@@ -290,11 +297,33 @@ fun NewExpenseEntryScreen(
                                         modifier = Modifier.align(Alignment.TopEnd)
                                     ) {
                                         Icon(
-                                            Icons.Default.Close, 
+                                            Icons.Default.Close,
                                             contentDescription = "Remove photo",
                                             tint = MaterialTheme.colorScheme.error
                                         )
                                     }
+                                }
+                            }
+                        }
+                    }
+
+                    if (uiState.existingPhotoUrls.isNotEmpty()) {
+                        LazyRow(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            items(uiState.existingPhotoUrls) { url ->
+                                Box(
+                                    modifier = Modifier
+                                        .size(100.dp)
+                                ) {
+                                    AsyncImage(
+                                        model = url,
+                                        contentDescription = "Existing photo",
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .clip(RoundedCornerShape(8.dp))
+                                    )
                                 }
                             }
                         }
@@ -334,6 +363,7 @@ fun NewExpenseEntryScreen(
             }
             
             // Save button
+            val actionLabel = if (uiState.isEditing) "Update Expense" else "Save Expense"
             Button(
                 onClick = viewModel::saveExpense,
                 enabled = uiState.canSave && !uiState.isSaving,
@@ -348,7 +378,7 @@ fun NewExpenseEntryScreen(
                     )
                 } else {
                     Text(
-                        text = "Save Expense",
+                        text = actionLabel,
                         modifier = Modifier.padding(8.dp)
                     )
                 }

--- a/app/src/main/java/com/fleetmanager/ui/viewmodel/EntryListViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/viewmodel/EntryListViewModel.kt
@@ -3,21 +3,45 @@ package com.fleetmanager.ui.viewmodel
 import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.fleetmanager.domain.model.DailyEntry
+import com.fleetmanager.domain.model.Expense
 import com.fleetmanager.domain.model.UserRole
 import com.fleetmanager.domain.usecase.GetAllEntriesRealtimeUseCase
 import com.fleetmanager.data.remote.FirestoreService
 import com.fleetmanager.data.remote.UserFirestoreService
 import com.fleetmanager.data.remote.VehicleFirestoreService
 import com.fleetmanager.data.dto.UserDto
+import com.fleetmanager.domain.model.Vehicle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import javax.inject.Inject
+import java.util.Date
 
 data class EntryListUiState(
     val entries: List<DailyEntry> = emptyList(),
+    val expenses: List<Expense> = emptyList(),
     val isLoading: Boolean = true,
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
+    val filter: HistoryFilter = HistoryFilter.INCOME,
+    val isSelectionMode: Boolean = false,
+    val selectedEntryIds: Set<String> = emptySet(),
+    val driverUsers: List<UserDto> = emptyList(),
+    val vehicles: List<Vehicle> = emptyList(),
+    val isBulkEditing: Boolean = false,
+    val bulkEditMessage: String? = null,
+    val bulkEditError: String? = null
 )
+
+data class HistoryData(
+    val entries: List<DailyEntry>,
+    val expenses: List<Expense>,
+    val driverUsers: List<UserDto>,
+    val vehicles: List<Vehicle>
+)
+
+enum class HistoryFilter {
+    INCOME,
+    EXPENSE
+}
 
 @HiltViewModel
 class EntryListViewModel @Inject constructor(
@@ -26,7 +50,8 @@ class EntryListViewModel @Inject constructor(
     private val userFirestoreService: UserFirestoreService,
     private val vehicleFirestoreService: VehicleFirestoreService,
     private val authRepository: com.fleetmanager.domain.repository.AuthRepository,
-    private val deleteDailyEntryUseCase: com.fleetmanager.domain.usecase.DeleteDailyEntryUseCase
+    private val deleteDailyEntryUseCase: com.fleetmanager.domain.usecase.DeleteDailyEntryUseCase,
+    private val saveDailyEntryUseCase: com.fleetmanager.domain.usecase.SaveDailyEntryUseCase
 ) : BaseViewModel<EntryListUiState>() {
     
     companion object {
@@ -84,10 +109,11 @@ class EntryListViewModel @Inject constructor(
             userRole.collect { role ->
                 combine(
                     firestoreService.getDailyEntriesFlowForRole(role),
+                    firestoreService.getExpensesFlowForRole(role),
                     userFirestoreService.getDriverUsersFlow(),
                     vehicleFirestoreService.getVehiclesFlow()
-                ) { entries, driverUsers, vehicles ->
-                    Triple(entries, driverUsers, vehicles)
+                ) { entries, expenses, driverUsers, vehicles ->
+                    HistoryData(entries, expenses, driverUsers, vehicles)
                 }
                     .catch { e ->
                         Log.e(TAG, "Firestore snapshot listener error", e)
@@ -98,7 +124,7 @@ class EntryListViewModel @Inject constructor(
                             ) 
                         }
                     }
-                    .collect { (entries, driverUsers, vehicles) ->
+                    .collect { (entries, expenses, driverUsers, vehicles) ->
                         Log.d(TAG, "Received ${entries.size} entries for role $role")
                         val driverNameMap = driverUsers.associateBy({ it.id }, { it.name })
                         val vehicleNameMap = vehicles.associateBy({ it.id }, { it.displayName })
@@ -110,9 +136,13 @@ class EntryListViewModel @Inject constructor(
                         }
                         // Sort entries by date descending (most recent first)
                         val sortedEntries = enrichedEntries.sortedByDescending { it.date }
+                        val sortedExpenses = expenses.sortedByDescending { it.date }
                         updateState {
                             it.copy(
                                 entries = sortedEntries,
+                                expenses = sortedExpenses,
+                                driverUsers = driverUsers,
+                                vehicles = vehicles,
                                 isLoading = false,
                                 errorMessage = null
                             )
@@ -131,6 +161,121 @@ class EntryListViewModel @Inject constructor(
         ) {
             deleteDailyEntryUseCase(entryId)
             onSuccess?.invoke()
+        }
+    }
+
+    fun updateFilter(filter: HistoryFilter) {
+        updateState {
+            if (it.filter == filter) it else it.copy(
+                filter = filter,
+                isSelectionMode = false,
+                selectedEntryIds = emptySet()
+            )
+        }
+    }
+
+    fun startBulkEdit() {
+        updateState { it.copy(isSelectionMode = true, selectedEntryIds = emptySet()) }
+    }
+
+    fun cancelBulkEdit() {
+        updateState {
+            it.copy(
+                isSelectionMode = false,
+                selectedEntryIds = emptySet(),
+                isBulkEditing = false
+            )
+        }
+    }
+
+    fun toggleEntrySelection(entryId: String) {
+        updateState { currentState ->
+            val mutableSelection = currentState.selectedEntryIds.toMutableSet()
+            if (!mutableSelection.add(entryId)) {
+                mutableSelection.remove(entryId)
+            }
+            currentState.copy(
+                selectedEntryIds = mutableSelection,
+                isSelectionMode = true && mutableSelection.isNotEmpty()
+            )
+        }
+    }
+
+    fun clearSelectionIfEmpty() {
+        val currentState = uiState.value
+        if (currentState.selectedEntryIds.isEmpty() && currentState.isSelectionMode) {
+            updateState { it.copy(isSelectionMode = false) }
+        }
+    }
+
+    fun selectAllEntries() {
+        val allIds = uiState.value.entries.map { it.id }.toSet()
+        updateState { it.copy(selectedEntryIds = allIds, isSelectionMode = allIds.isNotEmpty()) }
+    }
+
+    fun clearBulkEditMessage() {
+        updateState { it.copy(bulkEditMessage = null) }
+    }
+
+    fun clearBulkEditError() {
+        updateState { it.copy(bulkEditError = null) }
+    }
+
+    fun bulkUpdateSelectedEntries(driverId: String, vehicleId: String) {
+        val currentState = uiState.value
+        val driver = currentState.driverUsers.firstOrNull { it.id == driverId }
+        val vehicle = currentState.vehicles.firstOrNull { it.id == vehicleId }
+
+        if (driver == null || vehicle == null) {
+            updateState {
+                it.copy(bulkEditError = "Please select valid driver and vehicle")
+            }
+            return
+        }
+
+        val entriesToUpdate = currentState.entries.filter { currentState.selectedEntryIds.contains(it.id) }
+        if (entriesToUpdate.isEmpty()) {
+            updateState { it.copy(bulkEditError = "Select at least one entry to update") }
+            return
+        }
+
+        executeAsync(
+            onLoading = { isLoading ->
+                updateState { it.copy(isBulkEditing = isLoading, bulkEditError = null) }
+            },
+            onError = { error ->
+                updateState {
+                    it.copy(
+                        isBulkEditing = false,
+                        bulkEditError = error,
+                        bulkEditMessage = null
+                    )
+                }
+            }
+        ) {
+            entriesToUpdate.forEach { entry ->
+                val updatedEntry = entry.copy(
+                    driverId = driver.id,
+                    driverName = driver.name,
+                    vehicleId = vehicle.id,
+                    vehicle = vehicle.displayName,
+                    updatedAt = Date(),
+                    userId = entry.userId
+                )
+
+                val result = saveDailyEntryUseCase(updatedEntry)
+                result.getOrThrow()
+            }
+
+            updateState {
+                it.copy(
+                    isBulkEditing = false,
+                    isSelectionMode = false,
+                    selectedEntryIds = emptySet(),
+                    bulkEditMessage = "Updated ${entriesToUpdate.size} entries",
+                    bulkEditError = null
+                )
+            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="welcome">Welcome to Fleet Manager</string>
     <string name="manage_your_fleet">Manage your fleet earnings and expenses</string>
     <string name="add_entry">Add Entry</string>
+    <string name="edit_entry">Edit Entry</string>
     <string name="entries">Entries</string>
     <string name="driver_name">Driver Name</string>
     <string name="vehicle">Vehicle</string>
@@ -15,6 +16,7 @@
     <string name="notes">Notes</string>
     <string name="date">Date</string>
     <string name="save">Save</string>
+    <string name="update_entry">Update</string>
     <string name="cancel">Cancel</string>
     <string name="photo">Photo</string>
     <string name="take_photo">Take Photo</string>


### PR DESCRIPTION
## Summary
- add admin filter chips, expense support, and bulk edit UX on the history screen
- extend daily entry tiles, add edit routes, and wire navigation for entry/expense editing
- support editing in entry/expense flows, preserve record owners, and expose get-expense use case

## Testing
- ./gradlew test *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d1cd5914a8832384b08f8a9d439ef9