### PR TITLE
Add Cloud Function to provision driver on user sign-up

### DIFF
--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -1,0 +1,46 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+
+admin.initializeApp();
+
+/**
+ * Cloud Function triggered whenever a new Firebase Authentication user is created.
+ * It automatically provisions a matching driver document in the `drivers` collection
+ * so the mobile app immediately has a driver entity available for the new account.
+ */
+exports.createDriverForNewUser = functions.auth.user().onCreate(async (user) => {
+  const driverId = user.uid;
+  const firestore = admin.firestore();
+  const driverRef = firestore.collection('drivers').doc(driverId);
+
+  try {
+    const existingDriver = await driverRef.get();
+    if (existingDriver.exists) {
+      functions.logger.info('Driver already exists for user, skipping creation.', { userId: driverId });
+      return null;
+    }
+
+    const now = admin.firestore.FieldValue.serverTimestamp();
+    const displayName = (user.displayName || '').trim();
+    const derivedName = displayName || (user.email ? user.email.split('@')[0] : 'Nouveau conducteur');
+
+    const driverPayload = {
+      id: driverId,
+      userId: driverId,
+      name: derivedName,
+      isActive: true,
+      salary: 0.0,
+      annualLicenseCost: 0.0,
+      annualVisaCost: 0.0,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await driverRef.set(driverPayload);
+    functions.logger.info('Driver created successfully for new user.', { userId: driverId });
+    return null;
+  } catch (error) {
+    functions.logger.error('Failed to create driver for new user.', { userId: driverId, error: error.message });
+    throw error;
+  }
+});

--- a/firebase/functions/package.json
+++ b/firebase/functions/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "fleettrackr-functions",
+  "description": "Cloud Functions for FleetTrackr Firebase backend.",
+  "engines": {
+    "node": "18"
+  },
+  "main": "index.js",
+  "scripts": {
+    "build": "echo 'No build step required'",
+    "deploy": "firebase deploy --only functions"
+  },
+  "dependencies": {
+    "firebase-admin": "^11.11.1",
+    "firebase-functions": "^4.4.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add a Firebase Cloud Function that listens for new Authentication users
- automatically create a driver document populated with default values for the new account
- define a minimal package.json to deploy the function with the required dependencies

## Testing
- not run (serverless function code only)


------
https://chatgpt.com/codex/tasks/task_e_68d261339a448323958e9cb0da42981b