### PR TITLE
Auto-fill driver selection based on user role

### DIFF
--- a/app/src/main/java/com/fleetmanager/ui/viewmodel/AddEntryViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/viewmodel/AddEntryViewModel.kt
@@ -123,15 +123,25 @@ class AddEntryViewModel @Inject constructor(
                 Pair(driverUsers, vehicles)
             }.collect { (driverUsers, vehicles) ->
                 updateState { currentState ->
+                    val autoFilledDriverName = if (shouldAutoFillDriver(currentState)) {
+                        val userProfile = currentState.currentUserProfile
+                        driverUsers.firstOrNull { it.id == userProfile?.id }?.name
+                            ?: userProfile?.name
+                            ?: currentState.driverInput
+                    } else {
+                        currentState.driverInput
+                    }
+
                     currentState.copy(
                         driverUsers = driverUsers,
-                        vehicles = vehicles
+                        vehicles = vehicles,
+                        driverInput = autoFilledDriverName
                     )
                 }
             }
         }
     }
-    
+
     private fun loadUserProfile() {
         executeAsync(
             onError = { error ->
@@ -139,14 +149,31 @@ class AddEntryViewModel @Inject constructor(
             }
         ) {
             userFirestoreService.getCurrentUserProfile().collect { userProfile ->
-                updateState { 
-                    it.copy(
+                updateState { currentState ->
+                    val updatedState = currentState.copy(
                         currentUserProfile = userProfile,
                         userRole = userProfile.role
-                    ) 
+                    )
+
+                    if (shouldAutoFillDriver(updatedState)) {
+                        val driverName = updatedState.driverUsers.firstOrNull { it.id == userProfile.id }?.name
+                            ?: userProfile.name
+
+                        updatedState.copy(driverInput = driverName)
+                    } else {
+                        updatedState
+                    }
                 }
             }
         }
+    }
+
+    private fun shouldAutoFillDriver(state: AddEntryUiState): Boolean {
+        val role = state.userRole ?: state.currentUserProfile?.role
+        if (state.isEditing || state.driverInput.isNotBlank()) {
+            return false
+        }
+        return role == UserRole.DRIVER || role == UserRole.MANAGER
     }
     
     fun selectDriver(driver: Driver) {


### PR DESCRIPTION
## Summary
- auto-fill the driver field for new income/expense entries when the current user is a driver or manager
- keep managers able to override the selection while limiting manual selection to admin/manager roles
- derive the default value from the driver collection so driver users are pre-populated correctly

## Testing
- ./gradlew test *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2625aecac8323893a8ecafd0deaca