### PR TITLE
Fix driver and vehicle ownership sync for admin visibility

### DIFF
--- a/app/src/main/java/com/fleetmanager/data/repository/FleetRepositoryImpl.kt
+++ b/app/src/main/java/com/fleetmanager/data/repository/FleetRepositoryImpl.kt
@@ -183,11 +183,12 @@ class FleetRepositoryImpl @Inject constructor(
         driverDao.getAllDrivers().map { DriverMapper.toDomainList(it) }
     
     override suspend fun saveDriver(driver: Driver) {
-        val userId = authService.getCurrentUserId() ?: ""
-        val driverWithUserId = driver.copy(userId = userId)
-        driverDao.insertDriver(DriverMapper.toDto(driverWithUserId))
+        val currentUserId = authService.getCurrentUserId() ?: ""
+        val ownerId = driver.userId.takeIf { it.isNotBlank() } ?: currentUserId
+        val driverToPersist = driver.copy(userId = ownerId)
+        driverDao.insertDriver(DriverMapper.toDto(driverToPersist))
         try {
-            firestoreService.saveDriver(driverWithUserId)
+            firestoreService.saveDriver(driverToPersist)
         } catch (e: Exception) {
             val errorMessage = "Failed to save driver to Firestore: ${e.message}"
             Log.e(TAG, errorMessage, e)
@@ -230,11 +231,12 @@ class FleetRepositoryImpl @Inject constructor(
         vehicleDao.getAllVehicles().map { VehicleMapper.toDomainList(it) }
 
     override suspend fun saveVehicle(vehicle: Vehicle) {
-        val userId = authService.getCurrentUserId() ?: ""
-        val vehicleWithUserId = vehicle.copy(userId = userId)
-        vehicleDao.insertVehicle(VehicleMapper.toDto(vehicleWithUserId))
+        val currentUserId = authService.getCurrentUserId() ?: ""
+        val ownerId = vehicle.userId.takeIf { it.isNotBlank() } ?: currentUserId
+        val vehicleToPersist = vehicle.copy(userId = ownerId)
+        vehicleDao.insertVehicle(VehicleMapper.toDto(vehicleToPersist))
         try {
-            firestoreService.saveVehicle(vehicleWithUserId)
+            firestoreService.saveVehicle(vehicleToPersist)
         } catch (e: Exception) {
             val errorMessage = "Failed to save vehicle to Firestore: ${e.message}"
             Log.e(TAG, errorMessage, e)


### PR DESCRIPTION
## Summary
- update FirestoreService so admin and manager roles can fetch the full fleet of drivers and vehicles while preserving original ownership when saving
- make the repository respect existing driver and vehicle owners to keep auto-created resources linked to the correct user

## Testing
- `./gradlew lint` *(fails: SDK location not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d28aa39614832396a43792eb15894e