### PR TITLE
Ensure drivers list syncs from Firestore

### DIFF
--- a/app/src/main/java/com/fleetmanager/ui/viewmodel/DriverManagementViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/viewmodel/DriverManagementViewModel.kt
@@ -43,6 +43,14 @@ class DriverManagementViewModel @Inject constructor(
             onError = { error -> updateState { it.copy(error = error, isLoading = false) } }
         ) {
             updateState { it.copy(isLoading = true) }
+            runCatching { fleetRepository.syncDrivers() }
+                .onFailure { exception ->
+                    updateState {
+                        it.copy(
+                            error = exception.message ?: "Failed to refresh drivers"
+                        )
+                    }
+                }
             fleetRepository.getAllDrivers().collect { drivers ->
                 updateState {
                     it.copy(


### PR DESCRIPTION
## Summary
- trigger a Firestore sync before collecting the driver list so remote data populates the local cache
- surface sync failures as non-blocking UI errors while continuing to show cached drivers

## Testing
- ./gradlew testDebugUnitTest *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d2902e7d688323835d0a119ad23cdf