### PR TITLE
Switch driver lookups to driver collection

### DIFF
--- a/app/src/main/java/com/fleetmanager/ui/screens/entry/EntryListScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/entry/EntryListScreen.kt
@@ -27,7 +27,7 @@ import com.fleetmanager.ui.components.*
 import com.fleetmanager.ui.utils.collectAsStateWithLifecycle
 import com.fleetmanager.ui.utils.rememberStableLambda0
 import com.fleetmanager.ui.utils.rememberStableLambda1
-import com.fleetmanager.data.dto.UserDto
+import com.fleetmanager.domain.model.Driver
 import com.fleetmanager.domain.model.Vehicle
 import com.fleetmanager.ui.viewmodel.HistoryFilter
 import java.text.SimpleDateFormat
@@ -320,7 +320,7 @@ fun EntryListScreen(
 
         if (showBulkEditDialog) {
             BulkEditDialog(
-                driverOptions = uiState.driverUsers,
+                driverOptions = uiState.drivers,
                 vehicleOptions = uiState.vehicles,
                 isProcessing = uiState.isBulkEditing,
                 onDismiss = {
@@ -467,7 +467,7 @@ private fun BulkEditSelectionBar(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun BulkEditDialog(
-    driverOptions: List<UserDto>,
+    driverOptions: List<Driver>,
     vehicleOptions: List<Vehicle>,
     isProcessing: Boolean,
     onDismiss: () -> Unit,

--- a/app/src/main/java/com/fleetmanager/ui/screens/report/ReportScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/report/ReportScreen.kt
@@ -148,7 +148,7 @@ fun ReportScreen(
             CollapsibleFiltersSection(
                 isExpanded = isFilterExpanded,
                 onToggleExpanded = { viewModel.toggleFilterPanel() },
-                drivers = uiState.driverUsers.map { it.name },
+                drivers = uiState.drivers.map { it.name },
                 vehicles = uiState.vehicles.map { it.displayName },
                 types = uiState.availableTypes,
                 selectedDriver = uiState.selectedDriver,

--- a/app/src/main/java/com/fleetmanager/ui/viewmodel/EntryDetailViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/viewmodel/EntryDetailViewModel.kt
@@ -6,7 +6,6 @@ import com.fleetmanager.domain.model.UserRole
 import com.fleetmanager.domain.usecase.GetEntryByIdUseCase
 import com.fleetmanager.domain.usecase.DeleteDailyEntryUseCase
 import com.fleetmanager.data.remote.FirestoreService
-import com.fleetmanager.data.remote.UserFirestoreService
 import com.fleetmanager.data.remote.VehicleFirestoreService
 import com.fleetmanager.data.dto.UserDto
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -24,7 +23,6 @@ class EntryDetailViewModel @Inject constructor(
     private val getEntryByIdUseCase: GetEntryByIdUseCase,
     private val deleteDailyEntryUseCase: DeleteDailyEntryUseCase,
     private val firestoreService: FirestoreService,
-    private val userFirestoreService: UserFirestoreService,
     private val vehicleFirestoreService: VehicleFirestoreService
 ) : BaseViewModel<EntryDetailUiState>() {
     
@@ -69,13 +67,13 @@ class EntryDetailViewModel @Inject constructor(
         ) {
             combine(
                 getEntryByIdUseCase(entryId),
-                userFirestoreService.getDriverUsersFlow(),
+                firestoreService.getDriversFlow(),
                 vehicleFirestoreService.getVehiclesFlow()
-            ) { entry, driverUsers, vehicles ->
+            ) { entry, drivers, vehicles ->
                 if (entry == null) {
                     null
                 } else {
-                    val driverNameMap = driverUsers.associateBy({ it.id }, { it.name })
+                    val driverNameMap = drivers.associateBy({ it.id }, { it.name })
                     val vehicleNameMap = vehicles.associateBy({ it.id }, { it.displayName })
                     entry.withResolvedDisplayData(
                         driverDisplayName = driverNameMap[entry.driverId],


### PR DESCRIPTION
## Summary
- add a Firestore realtime flow for drivers sourced from the driver collection
- update entry, expense, and report view models plus related UIs to consume driver data from the driver collection
- ensure bulk edit, filters, and auto-fill logic resolve drivers via their driver documents instead of user records

## Testing
- `./gradlew lint` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d294859d9c832393e7078755c31c26