### PR TITLE
Fix driver filtering and vehicle cost allocation in analytics

### DIFF
--- a/app/src/main/java/com/fleetmanager/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/analytics/AnalyticsViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import com.fleetmanager.data.remote.FirestoreService
+import com.fleetmanager.data.remote.VehicleFirestoreService
 import com.fleetmanager.data.remote.UserFirestoreService
 import com.fleetmanager.data.dto.UserDto
 import com.fleetmanager.domain.model.DailyEntry
@@ -27,7 +28,7 @@ import java.time.LocalDate
 import java.time.YearMonth
 import java.time.ZoneId
 import java.util.Date
-import java.util.concurrent.TimeUnit
+import java.util.Locale
 import javax.inject.Inject
 
 /**
@@ -78,7 +79,8 @@ data class DriverFilterState(
 class AnalyticsViewModel @Inject constructor(
     private val fleetRepository: FleetRepository,
     private val userFirestoreService: UserFirestoreService,
-    private val firestoreService: FirestoreService
+    private val firestoreService: FirestoreService,
+    private val vehicleFirestoreService: VehicleFirestoreService
 ) : ViewModel() {
     
     private val _uiState = MutableStateFlow(AnalyticsUiState())
@@ -149,7 +151,7 @@ class AnalyticsViewModel @Inject constructor(
                 combine(
                     fleetRepository.getAllDailyEntriesRealtime(),
                     firestoreService.getDriversFlow(),
-                    fleetRepository.getAllVehicles()
+                    vehicleFirestoreService.getVehiclesFlow()
                 ) { entries, drivers, vehicles ->
                     val driverNameMap = drivers.associateBy({ it.id }, { it.name })
                     val vehicleNameMap = vehicles.associateBy({ it.id }, { it.displayName })
@@ -210,7 +212,7 @@ class AnalyticsViewModel @Inject constructor(
                     .combine(firestoreService.getDriversFlow()) { snapshot, drivers ->
                         snapshot.copy(drivers = drivers)
                     }
-                    .combine(fleetRepository.getAllVehicles()) { snapshot, vehicles ->
+                    .combine(vehicleFirestoreService.getVehiclesFlow()) { snapshot, vehicles ->
                         snapshot.copy(vehicles = vehicles)
                     }
 
@@ -240,6 +242,7 @@ class AnalyticsViewModel @Inject constructor(
                         }
 
                         val driverNameMap = snapshot.drivers.associateBy({ it.id }, { it.name })
+                        val driverNameToId = snapshot.drivers.associate { normalizeName(it.name) to it.id }
                         val vehicleNameMap = snapshot.vehicles.associateBy({ it.id }, { it.displayName })
                         val enrichedEntries = snapshot.entries.map { entry ->
                             entry.withResolvedDisplayData(
@@ -259,23 +262,17 @@ class AnalyticsViewModel @Inject constructor(
                             expenseDate.isBefore(today) // Exclude current day (d-1 logic)
                         }
 
-                        val selectedDriver = resolvedDriverId?.let { id ->
-                            snapshot.drivers.firstOrNull { driver -> driver.id == id }
-                        }
-
                         val entriesByDriver = resolvedDriverId?.let { id ->
                             entriesExcludingToday.filter { entry ->
-                                entry.driverId == id || (
-                                    selectedDriver?.name?.let { driverName ->
-                                        entry.driverName.equals(driverName, ignoreCase = true)
-                                    } == true
-                                )
+                                resolveDriverId(entry, driverNameToId) == id
                             }
                         } ?: entriesExcludingToday
 
-                        val expensesByDriver = selectedDriver?.let { driver ->
+                        val expensesByDriver = resolvedDriverId?.let { id ->
+                            val normalizedDriverName = driverNameMap[id]?.let { normalizeName(it) }
                             expensesExcludingToday.filter { expense ->
-                                expense.driverName.equals(driver.name, ignoreCase = true)
+                                normalizedDriverName != null &&
+                                    normalizeName(expense.driverName) == normalizedDriverName
                             }
                         } ?: expensesExcludingToday
 
@@ -452,7 +449,15 @@ class AnalyticsViewModel @Inject constructor(
         }
 
         val vehiclesById = vehicles.associateBy { it.id }
-        val vehicleCostsByDriver = calculateVehicleCostAssignments(entries, vehiclesById, targetMonth)
+        val vehiclesByDisplayName = vehicles.associateBy { normalizeName(it.displayName) }
+        val driverNameToId = drivers.associate { driver -> normalizeName(driver.name) to driver.id }
+        val vehicleCostsByDriver = calculateVehicleCostAssignments(
+            entries,
+            vehiclesById,
+            vehiclesByDisplayName,
+            targetMonth,
+            driverNameToId
+        )
         val relevantDriverIds = if (driverIdsInScope.isEmpty()) {
             vehicleCostsByDriver.keys
         } else {
@@ -514,7 +519,9 @@ class AnalyticsViewModel @Inject constructor(
     private fun calculateVehicleCostAssignments(
         entries: List<DailyEntry>,
         vehiclesById: Map<String, Vehicle>,
-        targetMonth: YearMonth
+        vehiclesByDisplayName: Map<String, Vehicle>,
+        targetMonth: YearMonth,
+        driverNameToId: Map<String, String>
     ): Map<String, Double> {
         if (entries.isEmpty()) return emptyMap()
 
@@ -524,14 +531,16 @@ class AnalyticsViewModel @Inject constructor(
             .toInstant()
 
         return entries
-            .groupBy { it.driverId }
-            .mapNotNull { (driverId, driverEntries) ->
+            .groupBy { entry -> resolveDriverId(entry, driverNameToId) }
+            .mapNotNull { (resolvedDriverId, driverEntries) ->
+                val driverId = resolvedDriverId ?: return@mapNotNull null
                 val assignmentEntry = driverEntries
                     .filter { entry -> entry.date.toInstant() <= monthEndInstant }
                     .maxByOrNull { entry -> entry.date.time }
                     ?: return@mapNotNull null
 
-                val vehicle = vehiclesById[assignmentEntry.vehicleId] ?: return@mapNotNull null
+                val vehicle = resolveVehicle(assignmentEntry, vehiclesById, vehiclesByDisplayName)
+                    ?: return@mapNotNull null
                 driverId to vehicleMonthlyCost(vehicle)
             }
             .toMap()
@@ -539,6 +548,34 @@ class AnalyticsViewModel @Inject constructor(
 
     private fun vehicleMonthlyCost(vehicle: Vehicle): Double {
         return (vehicle.installment ?: 0.0) + (vehicle.annualInsuranceAmount / 12.0)
+    }
+
+    private fun resolveDriverId(entry: DailyEntry, driverNameToId: Map<String, String>): String? {
+        val explicitId = entry.driverId.takeIf { it.isNotBlank() }
+        if (explicitId != null) {
+            return explicitId
+        }
+
+        val normalizedName = entry.driverName.takeIf { it.isNotBlank() }?.let { normalizeName(it) }
+        return normalizedName?.let { driverNameToId[it] }
+    }
+
+    private fun resolveVehicle(
+        entry: DailyEntry,
+        vehiclesById: Map<String, Vehicle>,
+        vehiclesByDisplayName: Map<String, Vehicle>
+    ): Vehicle? {
+        val vehicleById = entry.vehicleId.takeIf { it.isNotBlank() }?.let { vehiclesById[it] }
+        if (vehicleById != null) {
+            return vehicleById
+        }
+
+        val normalizedDisplayName = entry.vehicle.takeIf { it.isNotBlank() }?.let { normalizeName(it) }
+        return normalizedDisplayName?.let { vehiclesByDisplayName[it] }
+    }
+
+    private fun normalizeName(raw: String): String {
+        return raw.trim().lowercase(Locale.getDefault())
     }
     
     fun onDaySelected(date: LocalDate, entries: List<DailyEntry>) {

--- a/app/src/main/java/com/fleetmanager/ui/screens/analytics/AnalyticsViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/analytics/AnalyticsViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import com.fleetmanager.data.remote.FirestoreService
 import com.fleetmanager.data.remote.UserFirestoreService
 import com.fleetmanager.data.dto.UserDto
 import com.fleetmanager.domain.model.DailyEntry
@@ -76,7 +77,8 @@ data class DriverFilterState(
 @HiltViewModel
 class AnalyticsViewModel @Inject constructor(
     private val fleetRepository: FleetRepository,
-    private val userFirestoreService: UserFirestoreService
+    private val userFirestoreService: UserFirestoreService,
+    private val firestoreService: FirestoreService
 ) : ViewModel() {
     
     private val _uiState = MutableStateFlow(AnalyticsUiState())
@@ -146,7 +148,7 @@ class AnalyticsViewModel @Inject constructor(
                 
                 combine(
                     fleetRepository.getAllDailyEntriesRealtime(),
-                    fleetRepository.getAllDrivers(),
+                    firestoreService.getDriversFlow(),
                     fleetRepository.getAllActiveVehicles()
                 ) { entries, drivers, vehicles ->
                     val driverNameMap = drivers.associateBy({ it.id }, { it.name })
@@ -205,7 +207,7 @@ class AnalyticsViewModel @Inject constructor(
                     .combine(fleetRepository.getAllExpensesRealtime()) { entries, expenses ->
                         AnalyticsRealtimeSnapshot(entries = entries, expenses = expenses)
                     }
-                    .combine(fleetRepository.getAllDrivers()) { snapshot, drivers ->
+                    .combine(firestoreService.getDriversFlow()) { snapshot, drivers ->
                         snapshot.copy(drivers = drivers)
                     }
                     .combine(fleetRepository.getAllActiveVehicles()) { snapshot, vehicles ->


### PR DESCRIPTION
## Summary
- ensure the analytics driver filter matches entries using either the driver id or resolved driver name
- allocate vehicle fixed costs based on the latest entry in the month so the "All" scope net profit reflects driver-specific vehicle costs

## Testing
- ./gradlew test *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5021900288323a302f414da5d41d8