### PR TITLE
Fix dashboard earnings tiles visibility for all roles

### DIFF
--- a/app/src/main/java/com/fleetmanager/ui/viewmodel/DashboardViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/viewmodel/DashboardViewModel.kt
@@ -141,37 +141,33 @@ class DashboardViewModel @Inject constructor(
                     }
                 }
                 
-                // Only show earnings stats for admin users
-                val earningsStats = if (isAdmin) {
-                    listOf(
-                        StatItem(
-                            icon = Icons.Default.AttachMoney,
-                            value = "$${String.format("%.0f", dashboardData.thisMonthUberEarnings)}",
-                            label = "Uber (Month)",
-                            shortcut = DashboardShortcut.IncomeSource.Uber
-                        ),
-                        StatItem(
-                            icon = Icons.Default.AttachMoney,
-                            value = "$${String.format("%.0f", dashboardData.thisMonthYangoEarnings)}",
-                            label = "Yango (Month)",
-                            shortcut = DashboardShortcut.IncomeSource.Yango
-                        ),
-                        StatItem(
-                            icon = Icons.Default.AttachMoney,
-                            value = "$${String.format("%.0f", dashboardData.thisMonthPrivateEarnings)}",
-                            label = "Private (Month)",
-                            shortcut = DashboardShortcut.IncomeSource.Private
-                        ),
-                        StatItem(
-                            icon = Icons.Default.Assignment,
-                            value = "${dashboardData.recentEntries.size}",
-                            label = "Recent Entries",
-                            shortcut = DashboardShortcut.AllEntries
-                        )
+                // Always show earnings stats so the layout stays consistent across roles
+                val earningsStats = listOf(
+                    StatItem(
+                        icon = Icons.Default.AttachMoney,
+                        value = "$${String.format("%.0f", dashboardData.thisMonthUberEarnings)}",
+                        label = "Uber (Month)",
+                        shortcut = DashboardShortcut.IncomeSource.Uber
+                    ),
+                    StatItem(
+                        icon = Icons.Default.AttachMoney,
+                        value = "$${String.format("%.0f", dashboardData.thisMonthYangoEarnings)}",
+                        label = "Yango (Month)",
+                        shortcut = DashboardShortcut.IncomeSource.Yango
+                    ),
+                    StatItem(
+                        icon = Icons.Default.AttachMoney,
+                        value = "$${String.format("%.0f", dashboardData.thisMonthPrivateEarnings)}",
+                        label = "Private (Month)",
+                        shortcut = DashboardShortcut.IncomeSource.Private
+                    ),
+                    StatItem(
+                        icon = Icons.Default.Assignment,
+                        value = "${dashboardData.recentEntries.size}",
+                        label = "Recent Entries",
+                        shortcut = DashboardShortcut.AllEntries
                     )
-                } else {
-                    emptyList() // Hide all earnings stats for non-admin users
-                }
+                )
 
                 // Use actual DailyEntry objects for complete data
                 val recentEntries = dashboardData.recentEntries


### PR DESCRIPTION
## Summary
- always populate the dashboard earnings-by-source tiles so they appear for every role
- keep quick stats behavior unchanged while making the layout consistent

## Testing
- `./gradlew test` *(fails: Android SDK not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5129fd248832384a8eaa6512e6d97