### PR TITLE
Set splash screen background to pure black

### DIFF
--- a/app/src/main/java/com/fleetmanager/ui/screens/splash/SplashScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/splash/SplashScreen.kt
@@ -5,12 +5,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.fleetmanager.R
 import kotlinx.coroutines.delay
@@ -27,7 +27,7 @@ fun SplashScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
+            .background(Color.Black),
         contentAlignment = Alignment.Center
     ) {
         Image(


### PR DESCRIPTION
## Summary
- update the splash screen container to use a true black background that matches the logo asset

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dcd9ffabcc8323a1f4cc466121e445