### PR TITLE
Fix splash logo scaling

### DIFF
--- a/app/src/main/java/com/fleetmanager/ui/screens/splash/SplashScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/splash/SplashScreen.kt
@@ -31,7 +31,7 @@ fun SplashScreen(
         contentAlignment = Alignment.Center
     ) {
         Image(
-            painter = painterResource(id = R.mipmap.ic_launcher_foreground),
+            painter = painterResource(id = R.drawable.ic_app_logo),
             contentDescription = "AG Motion Logo",
             modifier = Modifier.size(200.dp)
         )


### PR DESCRIPTION
## Summary
- display the splash screen logo using the dedicated drawable asset instead of the adaptive launcher icon so its size stays constant

## Testing
- Not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dce22644dc8323bc4e0569c08d7cae