### PR TITLE
feat: add branded save spinner

### DIFF
--- a/app/src/main/java/com/fleetmanager/ui/components/FleetLoadingWheel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/components/FleetLoadingWheel.kt
@@ -1,0 +1,118 @@
+package com.fleetmanager.ui.components
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.center
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.toRadians
+
+/**
+ * Fleet branded loading wheel used for inline progress indicators.
+ */
+@Composable
+fun FleetLoadingWheel(
+    modifier: Modifier = Modifier,
+    indicatorSize: Dp = 24.dp,
+    strokeWidth: Dp = 3.dp,
+    colors: List<Color> = emptyList(),
+    trackColor: Color = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)
+) {
+    val colorScheme = MaterialTheme.colorScheme
+    val indicatorColors = remember(colors, colorScheme) {
+        if (colors.isNotEmpty()) {
+            colors
+        } else {
+            listOf(
+                colorScheme.primary,
+                colorScheme.tertiary,
+                colorScheme.primary
+            )
+        }
+    }
+
+    val transition = rememberInfiniteTransition(label = "fleet_loading_wheel_transition")
+    val rotation by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1400, easing = LinearEasing)
+        ),
+        label = "fleet_loading_wheel_rotation"
+    )
+
+    val sweep by transition.animateFloat(
+        initialValue = 70f,
+        targetValue = 320f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1200, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "fleet_loading_wheel_sweep"
+    )
+
+    Canvas(
+        modifier = modifier
+            .graphicsLayer { rotationZ = rotation }
+            .size(indicatorSize)
+    ) {
+        val stroke = Stroke(width = strokeWidth.toPx(), cap = StrokeCap.Round)
+        val resolvedTrackColor = if (trackColor.alpha > 0f) trackColor else colorScheme.primary.copy(alpha = 0.2f)
+
+        drawArc(
+            color = resolvedTrackColor,
+            startAngle = 0f,
+            sweepAngle = 360f,
+            useCenter = false,
+            style = stroke,
+            alpha = 0.35f
+        )
+
+        drawArc(
+            brush = Brush.sweepGradient(colors = indicatorColors, center = center),
+            startAngle = -90f,
+            sweepAngle = sweep,
+            useCenter = false,
+            style = stroke
+        )
+
+        if (sweep > 0f) {
+            val radius = (size.minDimension / 2f).coerceAtLeast(0f) - stroke.width / 2f
+            val endAngle = toRadians((-90f + sweep).toDouble())
+            val dotCenter = Offset(
+                x = center.x + cos(endAngle).toFloat() * radius,
+                y = center.y + sin(endAngle).toFloat() * radius
+            )
+
+            val glowRadius = stroke.width * 1.8f
+            drawCircle(
+                brush = Brush.radialGradient(
+                    colors = listOf(indicatorColors.last(), indicatorColors.last().copy(alpha = 0f)),
+                    center = dotCenter,
+                    radius = glowRadius * 1.6f
+                ),
+                radius = glowRadius,
+                center = dotCenter
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/fleetmanager/ui/screens/entry/AddEntryScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/entry/AddEntryScreen.kt
@@ -28,8 +28,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.fleetmanager.ui.viewmodel.AddEntryViewModel
 import com.fleetmanager.ui.components.DriverInputComponent
-import coil.compose.AsyncImage
 import com.fleetmanager.R
+import com.fleetmanager.ui.components.FleetLoadingWheel
+import coil.compose.AsyncImage
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -354,10 +355,9 @@ fun AddEntryScreen(
                 shape = RoundedCornerShape(12.dp)
             ) {
                 if (uiState.isSaving) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(20.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.onPrimary
+                    FleetLoadingWheel(
+                        indicatorSize = 20.dp,
+                        strokeWidth = 2.dp
                     )
                 } else {
                     Text(


### PR DESCRIPTION
## Summary
- add a reusable FleetLoadingWheel composable to render the branded animated progress ring
- replace the Add Entry save button spinner with the new loading wheel for a richer loading experience

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd76301d48323baf15249af3ae64d