### PR TITLE
Migrate app to Firestore entriesNEW schema

### DIFF
--- a/app/src/main/java/com/fleetmanager/data/dto/DailyEntryDto.kt
+++ b/app/src/main/java/com/fleetmanager/data/dto/DailyEntryDto.kt
@@ -16,15 +16,15 @@ data class DailyEntryDto(
     val date: Date,
     val driverId: String = "",
     val vehicleId: String = "",
-    val uberEarnings: Double,
-    val yangoEarnings: Double,
-    val privateJobsEarnings: Double,
+    val earnings: List<EarningDto> = emptyList(),
+    val odometer: Double? = null,
     val notes: String,
     val photoUrl: String? = null,
     val localPhotoPath: String? = null,
     val photoUrls: List<String> = emptyList(),
     val localPhotoPaths: List<String> = emptyList(),
     val isSynced: Boolean = false,
+    val totalEarnings: Double = 0.0,
     val createdAt: Date = Date(),
     val updatedAt: Date = Date()
 )

--- a/app/src/main/java/com/fleetmanager/data/dto/EarningDto.kt
+++ b/app/src/main/java/com/fleetmanager/data/dto/EarningDto.kt
@@ -1,0 +1,35 @@
+package com.fleetmanager.data.dto
+
+import com.fleetmanager.domain.model.EarningEntry
+
+/**
+ * DTO representation of an earning entry for Room persistence.
+ */
+data class EarningDto(
+    val provider: String = "",
+    val cardEarnings: Double = 0.0,
+    val cashEarnings: Double = 0.0,
+    val tips: Double = 0.0,
+    val tripCount: Int = 0,
+    val hoursOnline: Double = 0.0
+) {
+    fun toDomain(): EarningEntry = EarningEntry(
+        provider = provider,
+        cardEarnings = cardEarnings,
+        cashEarnings = cashEarnings,
+        tips = tips,
+        tripCount = tripCount,
+        hoursOnline = hoursOnline
+    )
+
+    companion object {
+        fun fromDomain(entry: EarningEntry): EarningDto = EarningDto(
+            provider = entry.provider,
+            cardEarnings = entry.cardEarnings,
+            cashEarnings = entry.cashEarnings,
+            tips = entry.tips,
+            tripCount = entry.tripCount,
+            hoursOnline = entry.hoursOnline
+        )
+    }
+}

--- a/app/src/main/java/com/fleetmanager/data/excel/CsvEntryFactory.kt
+++ b/app/src/main/java/com/fleetmanager/data/excel/CsvEntryFactory.kt
@@ -1,6 +1,7 @@
 package com.fleetmanager.data.excel
 
 import com.fleetmanager.domain.model.DailyEntry
+import com.fleetmanager.domain.model.EarningEntry
 import com.fleetmanager.domain.model.Driver
 import com.fleetmanager.domain.model.Vehicle
 import java.util.*
@@ -17,6 +18,13 @@ class CsvEntryFactory {
     fun createDailyEntry(rowData: CsvRowData, userId: String): DailyEntry {
         val currentUtcTime = Date() // Current time in UTC for audit trail
         
+        val earnings = buildList {
+            addIfPositive("Uber", rowData.uber)
+            addIfPositive("Careem", rowData.careem)
+            addIfPositive("Yango", rowData.yango)
+            addIfPositive("Private", rowData.private)
+        }
+
         return DailyEntry(
             id = UUID.randomUUID().toString(),
             userId = "PLACEHOLDER", // Will be corrected by ImportManager
@@ -25,16 +33,19 @@ class CsvEntryFactory {
             driverName = rowData.driver,
             vehicleId = rowData.vehicle.trim().lowercase(),
             vehicle = rowData.vehicle,
-            uberEarnings = rowData.uber,
-            yangoEarnings = rowData.yango,
-            privateJobsEarnings = rowData.private,
-            careemEarnings = rowData.careem,
+            earnings = earnings,
             notes = "Imported from CSV",
             photoUrls = emptyList(),
             isSynced = true,
             createdAt = currentUtcTime, // Import timestamp
             updatedAt = currentUtcTime  // Import timestamp
         )
+    }
+
+    private fun MutableList<EarningEntry>.addIfPositive(provider: String, amount: Double) {
+        if (amount > 0.0) {
+            add(EarningEntry(provider = provider, cardEarnings = amount))
+        }
     }
     
     /**

--- a/app/src/main/java/com/fleetmanager/data/local/Converters.kt
+++ b/app/src/main/java/com/fleetmanager/data/local/Converters.kt
@@ -1,6 +1,7 @@
 package com.fleetmanager.data.local
 
 import androidx.room.TypeConverter
+import com.fleetmanager.data.dto.EarningDto
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import java.util.Date
@@ -24,6 +25,18 @@ class Converters {
     @TypeConverter
     fun toStringList(value: String): List<String> {
         val listType = object : TypeToken<List<String>>() {}.type
+        return Gson().fromJson(value, listType) ?: emptyList()
+    }
+
+    @TypeConverter
+    fun fromEarningList(value: List<EarningDto>): String {
+        return Gson().toJson(value)
+    }
+
+    @TypeConverter
+    fun toEarningList(value: String): List<EarningDto> {
+        if (value.isBlank()) return emptyList()
+        val listType = object : TypeToken<List<EarningDto>>() {}.type
         return Gson().fromJson(value, listType) ?: emptyList()
     }
 }

--- a/app/src/main/java/com/fleetmanager/data/local/dao/DailyEntryDao.kt
+++ b/app/src/main/java/com/fleetmanager/data/local/dao/DailyEntryDao.kt
@@ -38,6 +38,6 @@ interface DailyEntryDao {
     @Query("UPDATE daily_entries SET isSynced = 1 WHERE id = :id")
     suspend fun markAsSynced(id: String)
     
-    @Query("SELECT SUM(uberEarnings + yangoEarnings + privateJobsEarnings) FROM daily_entries WHERE date BETWEEN :startDate AND :endDate")
+    @Query("SELECT SUM(totalEarnings) FROM daily_entries WHERE date BETWEEN :startDate AND :endDate")
     suspend fun getTotalEarningsForPeriod(startDate: Date, endDate: Date): Double
 }

--- a/app/src/main/java/com/fleetmanager/data/mapper/DailyEntryMapper.kt
+++ b/app/src/main/java/com/fleetmanager/data/mapper/DailyEntryMapper.kt
@@ -1,6 +1,7 @@
 package com.fleetmanager.data.mapper
 
 import com.fleetmanager.data.dto.DailyEntryDto
+import com.fleetmanager.data.dto.EarningDto
 import com.fleetmanager.domain.model.DailyEntry
 
 /**
@@ -15,9 +16,8 @@ object DailyEntryMapper {
             date = dto.date,
             driverId = dto.driverId,
             vehicleId = dto.vehicleId,
-            uberEarnings = dto.uberEarnings,
-            yangoEarnings = dto.yangoEarnings,
-            privateJobsEarnings = dto.privateJobsEarnings,
+            earnings = dto.earnings.map { it.toDomain() },
+            odometer = dto.odometer,
             notes = dto.notes,
             photoUrls = dto.photoUrls,
             isSynced = dto.isSynced,
@@ -25,7 +25,7 @@ object DailyEntryMapper {
             updatedAt = dto.updatedAt
         )
     }
-    
+
     fun toDto(domain: DailyEntry): DailyEntryDto {
         return DailyEntryDto(
             id = domain.id,
@@ -33,12 +33,12 @@ object DailyEntryMapper {
             date = domain.date,
             driverId = domain.driverId,
             vehicleId = domain.vehicleId,
-            uberEarnings = domain.uberEarnings,
-            yangoEarnings = domain.yangoEarnings,
-            privateJobsEarnings = domain.privateJobsEarnings,
+            earnings = domain.earnings.map { EarningDto.fromDomain(it) },
+            odometer = domain.odometer,
             notes = domain.notes,
             photoUrls = domain.photoUrls,
             isSynced = domain.isSynced,
+            totalEarnings = domain.totalEarnings,
             createdAt = domain.createdAt,
             updatedAt = domain.updatedAt
         )

--- a/app/src/main/java/com/fleetmanager/domain/model/EarningEntry.kt
+++ b/app/src/main/java/com/fleetmanager/domain/model/EarningEntry.kt
@@ -1,0 +1,49 @@
+package com.fleetmanager.domain.model
+
+import com.google.firebase.firestore.PropertyName
+
+/**
+ * Represents a single provider earning record for a daily entry.
+ */
+data class EarningEntry(
+    @get:PropertyName("provider")
+    val provider: String = "",
+
+    @get:PropertyName("cardEarnings")
+    val cardEarnings: Double = 0.0,
+
+    @get:PropertyName("cashEarnings")
+    val cashEarnings: Double = 0.0,
+
+    @get:PropertyName("tips")
+    val tips: Double = 0.0,
+
+    @get:PropertyName("tripCount")
+    val tripCount: Int = 0,
+
+    @get:PropertyName("hoursOnline")
+    val hoursOnline: Double = 0.0
+) {
+    val totalAmount: Double
+        get() = cardEarnings + cashEarnings + tips
+
+    fun isValid(): Boolean {
+        return provider.isNotBlank() &&
+                cardEarnings >= 0 &&
+                cashEarnings >= 0 &&
+                tips >= 0 &&
+                tripCount >= 0 &&
+                hoursOnline >= 0
+    }
+
+    fun getValidationErrors(): List<String> {
+        val errors = mutableListOf<String>()
+        if (provider.isBlank()) errors.add("Provider name is required")
+        if (cardEarnings < 0) errors.add("Card earnings for $provider cannot be negative")
+        if (cashEarnings < 0) errors.add("Cash earnings for $provider cannot be negative")
+        if (tips < 0) errors.add("Tips for $provider cannot be negative")
+        if (tripCount < 0) errors.add("Trip count for $provider cannot be negative")
+        if (hoursOnline < 0) errors.add("Hours online for $provider cannot be negative")
+        return errors
+    }
+}

--- a/app/src/main/java/com/fleetmanager/domain/usecase/DashboardAggregationUtils.kt
+++ b/app/src/main/java/com/fleetmanager/domain/usecase/DashboardAggregationUtils.kt
@@ -1,0 +1,73 @@
+package com.fleetmanager.domain.usecase
+
+import com.fleetmanager.domain.model.DailyEntry
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+internal fun aggregateTotalsByProvider(entries: List<DailyEntry>): Map<String, Double> {
+    val totals = mutableMapOf<String, Double>()
+    entries.forEach { entry ->
+        entry.earnings.forEach { earning ->
+            val key = normalizeProvider(earning.provider)
+            totals[key] = (totals[key] ?: 0.0) + earning.totalAmount
+        }
+    }
+    return totals
+}
+
+internal fun resolveProviderDisplayNames(entries: List<DailyEntry>): Map<String, String> {
+    val result = linkedMapOf<String, String>()
+    entries.forEach { entry ->
+        entry.earnings.forEach { earning ->
+            val key = normalizeProvider(earning.provider)
+            val displayName = earning.provider.trim().ifBlank { "Unknown" }
+            result.putIfAbsent(key, displayName)
+        }
+    }
+    return result
+}
+
+internal fun normalizeProvider(provider: String): String {
+    return provider.trim().lowercase(Locale.getDefault()).ifBlank { "unknown" }
+}
+
+internal fun generateDailyTrends(
+    entries: List<DailyEntry>,
+    referenceDate: Date,
+    providerKeys: Set<String>
+): Map<String, List<Double>> {
+    if (providerKeys.isEmpty()) return emptyMap()
+
+    val daysBack = 7
+    val result = providerKeys.associateWith { MutableList(daysBack) { 0.0 } }.toMutableMap()
+
+    (daysBack downTo 1).forEachIndexed { index, offset ->
+        val start = startOfDay(referenceDate, offset)
+        val end = Date(start.time + TimeUnit.DAYS.toMillis(1))
+
+        val windowEntries = entries.filter { it.date >= start && it.date < end }
+        providerKeys.forEach { key ->
+            val totalForDay = windowEntries.sumOf { entry ->
+                entry.earnings
+                    .filter { normalizeProvider(it.provider) == key }
+                    .sumOf { it.totalAmount }
+            }
+            result[key]?.set(index, totalForDay)
+        }
+    }
+
+    return result.mapValues { it.value.toList() }
+}
+
+internal fun startOfDay(referenceDate: Date, daysAgo: Int): Date {
+    val calendar = Calendar.getInstance()
+    calendar.time = referenceDate
+    calendar.add(Calendar.DAY_OF_YEAR, -daysAgo)
+    calendar.set(Calendar.HOUR_OF_DAY, 0)
+    calendar.set(Calendar.MINUTE, 0)
+    calendar.set(Calendar.SECOND, 0)
+    calendar.set(Calendar.MILLISECOND, 0)
+    return calendar.time
+}

--- a/app/src/main/java/com/fleetmanager/domain/usecase/SaveDailyEntryUseCase.kt
+++ b/app/src/main/java/com/fleetmanager/domain/usecase/SaveDailyEntryUseCase.kt
@@ -2,8 +2,10 @@ package com.fleetmanager.domain.usecase
 
 import android.net.Uri
 import com.fleetmanager.domain.model.DailyEntry
+import com.fleetmanager.domain.model.EarningEntry
 import com.fleetmanager.domain.repository.FleetRepository
 import com.fleetmanager.domain.validation.InputValidator
+import com.fleetmanager.domain.validation.ValidationResult
 import javax.inject.Inject
 
 /**
@@ -38,22 +40,71 @@ class SaveDailyEntryUseCase @Inject constructor(
         }
     }
     
-    private fun validateEntry(entry: DailyEntry): com.fleetmanager.domain.validation.ValidationResult {
-        return validator.validateAll(
+    private fun validateEntry(entry: DailyEntry): ValidationResult {
+        val baseValidation = validator.validateAll(
             { validator.validateText(entry.id, "Entry ID") },
             { validator.validateText(entry.driverId, "Driver ID") },
             { validator.validateText(entry.vehicleId, "Vehicle ID") },
-            { validator.validateEarnings(entry.uberEarnings.toString(), "Uber earnings") },
-            { validator.validateEarnings(entry.yangoEarnings.toString(), "Yango earnings") },
-            { validator.validateEarnings(entry.privateJobsEarnings.toString(), "Private jobs earnings") },
+            { validateEarningsList(entry.earnings) },
             { validator.validateNotes(entry.notes) },
             { validator.validateDate(entry.date) }
         )
+
+        if (baseValidation.isError) {
+            return baseValidation
+        }
+
+        return ValidationResult.Success
     }
-    
+
     private fun sanitizeEntry(entry: DailyEntry): DailyEntry {
         return entry.copy(
             notes = validator.sanitizeText(entry.notes)
         )
+    }
+
+    private fun validateEarningsList(earnings: List<EarningEntry>): ValidationResult {
+        if (earnings.isEmpty()) {
+            return ValidationResult.Error("At least one earning source is required")
+        }
+
+        val seenProviders = mutableSetOf<String>()
+
+        earnings.forEachIndexed { index, earning ->
+            val providerLabel = earning.provider.ifBlank { "Provider ${index + 1}" }
+
+            val providerValidation = validator.validateText(earning.provider, "Provider name")
+            if (providerValidation.isError) {
+                return providerValidation
+            }
+
+            val normalizedProvider = earning.provider.trim().lowercase()
+            if (!seenProviders.add(normalizedProvider)) {
+                return ValidationResult.Error("Duplicate provider '${earning.provider}' detected")
+            }
+
+            val validations = listOf(
+                validator.validateNonNegativeAmount(earning.cardEarnings, "$providerLabel card earnings", required = false),
+                validator.validateNonNegativeAmount(earning.cashEarnings, "$providerLabel cash earnings", required = false),
+                validator.validateNonNegativeAmount(earning.tips, "$providerLabel tips", required = false),
+                validator.validateNonNegativeAmount(earning.hoursOnline, "$providerLabel hours online", required = false)
+            )
+
+            validations.forEach { result ->
+                if (result.isError) {
+                    return result
+                }
+            }
+
+            if (earning.tripCount < 0) {
+                return ValidationResult.Error("$providerLabel trip count cannot be negative")
+            }
+
+            if (earning.totalAmount <= 0.0) {
+                return ValidationResult.Error("$providerLabel must have earnings greater than 0")
+            }
+        }
+
+        return ValidationResult.Success
     }
 }

--- a/app/src/main/java/com/fleetmanager/ui/components/DailyEntryTile.kt
+++ b/app/src/main/java/com/fleetmanager/ui/components/DailyEntryTile.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.fleetmanager.domain.model.DailyEntry
+import androidx.compose.ui.res.stringResource
+import com.fleetmanager.R
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -86,6 +88,16 @@ fun DailyEntryTile(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
+                    entry.odometer?.let { odometer ->
+                        Text(
+                            text = stringResource(
+                                R.string.odometer_reading,
+                                formatOdometer(odometer)
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
                 }
             }
 
@@ -150,14 +162,26 @@ fun DailyEntryTile(
             )
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        val earningItems = entry.earnings
+            .filter { it.totalAmount > 0 }
+            .map { earning ->
+                EarningItem(
+                    label = earning.provider.ifBlank { "Other" },
+                    amount = earning.totalAmount
+                )
+            }
 
-        EarningsChips(
-            earnings = listOf(
-                EarningItem("Uber", entry.uberEarnings),
-                EarningItem("Yango", entry.yangoEarnings),
-                EarningItem("Private", entry.privateJobsEarnings)
-            )
-        )
+        if (earningItems.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(8.dp))
+            EarningsChips(earnings = earningItems)
+        }
+    }
+}
+
+private fun formatOdometer(value: Double): String {
+    return if (value % 1.0 == 0.0) {
+        value.toLong().toString()
+    } else {
+        String.format(Locale.getDefault(), "%.1f", value)
     }
 }

--- a/app/src/main/java/com/fleetmanager/ui/model/ReportEntry.kt
+++ b/app/src/main/java/com/fleetmanager/ui/model/ReportEntry.kt
@@ -42,51 +42,30 @@ fun DailyEntry.toReportEntries(): List<ReportEntry> {
     val driverLabel = driverName.ifBlank { driverId }
     val vehicleLabel = vehicle.ifBlank { vehicleId }
 
-    if (uberEarnings > 0) {
-        entries.add(
-            ReportEntry(
-                id = "${id}_uber",
-                type = ReportEntryType.Income("Uber"),
-                amount = uberEarnings,
-                driverName = driverLabel,
-                vehicle = vehicleLabel,
-                date = date,
-                notes = notes,
-                isIncome = true
+    earnings
+        .filter { it.totalAmount > 0 }
+        .forEach { earning ->
+            val providerLabel = earning.provider.trim().ifBlank { "Earnings" }
+            val safeProviderId = providerLabel
+                .lowercase()
+                .replace("[^a-z0-9]".toRegex(), "_")
+                .replace(Regex("_+"), "_")
+                .trim('_')
+
+            entries.add(
+                ReportEntry(
+                    id = "${id}_${safeProviderId}",
+                    type = ReportEntryType.Income(providerLabel),
+                    amount = earning.totalAmount,
+                    driverName = driverLabel,
+                    vehicle = vehicleLabel,
+                    date = date,
+                    notes = notes,
+                    isIncome = true
+                )
             )
-        )
-    }
-    
-    if (yangoEarnings > 0) {
-        entries.add(
-            ReportEntry(
-                id = "${id}_yango",
-                type = ReportEntryType.Income("Yango"),
-                amount = yangoEarnings,
-                driverName = driverLabel,
-                vehicle = vehicleLabel,
-                date = date,
-                notes = notes,
-                isIncome = true
-            )
-        )
-    }
-    
-    if (privateJobsEarnings > 0) {
-        entries.add(
-            ReportEntry(
-                id = "${id}_private",
-                type = ReportEntryType.Income("Private"),
-                amount = privateJobsEarnings,
-                driverName = driverLabel,
-                vehicle = vehicleLabel,
-                date = date,
-                notes = notes,
-                isIncome = true
-            )
-        )
-    }
-    
+        }
+
     return entries
 }
 

--- a/app/src/main/java/com/fleetmanager/ui/model/UiModels.kt
+++ b/app/src/main/java/com/fleetmanager/ui/model/UiModels.kt
@@ -2,6 +2,7 @@ package com.fleetmanager.ui.model
 
 import androidx.compose.runtime.Stable
 import com.fleetmanager.domain.model.DailyEntry
+import com.fleetmanager.domain.model.EarningEntry
 import com.fleetmanager.domain.model.Driver
 import com.fleetmanager.domain.model.Vehicle
 import java.util.Date
@@ -19,9 +20,8 @@ data class UiDailyEntry(
     val driverName: String,
     val vehicleId: String,
     val vehicle: String,
-    val uberEarnings: Double,
-    val yangoEarnings: Double,
-    val privateJobsEarnings: Double,
+    val earnings: List<EarningEntry>,
+    val odometer: Double?,
     val notes: String,
     val photoUrls: List<String>,
     val isSynced: Boolean,
@@ -71,9 +71,8 @@ fun DailyEntry.toUiModel(dateFormatter: java.text.SimpleDateFormat): UiDailyEntr
         driverName = driverName,
         vehicleId = vehicleId,
         vehicle = vehicle,
-        uberEarnings = uberEarnings,
-        yangoEarnings = yangoEarnings,
-        privateJobsEarnings = privateJobsEarnings,
+        earnings = earnings,
+        odometer = odometer,
         notes = notes,
         photoUrls = photoUrls,
         isSynced = isSynced,

--- a/app/src/main/java/com/fleetmanager/ui/navigation/DashboardShortcut.kt
+++ b/app/src/main/java/com/fleetmanager/ui/navigation/DashboardShortcut.kt
@@ -11,11 +11,7 @@ sealed class DashboardShortcut {
         object LastMonth : TimeRange()
     }
 
-    sealed class IncomeSource : DashboardShortcut() {
-        object Uber : IncomeSource()
-        object Yango : IncomeSource()
-        object Private : IncomeSource()
-    }
+    data class Provider(val name: String) : DashboardShortcut()
 
     object AllEntries : DashboardShortcut()
 }

--- a/app/src/main/java/com/fleetmanager/ui/screens/analytics/DayEntriesDialog.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/analytics/DayEntriesDialog.kt
@@ -10,11 +10,13 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.fleetmanager.domain.model.DailyEntry
+import com.fleetmanager.R
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -153,30 +155,28 @@ private fun EntryCard(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
-            
+
             Spacer(modifier = Modifier.height(8.dp))
-            
+
+            entry.odometer?.let { odometer ->
+                Text(
+                    text = stringResource(R.string.odometer_reading, formatOdometer(odometer)),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
             // Earnings breakdown
-            if (entry.uberEarnings > 0) {
-                EarningsRow(
-                    label = "Uber",
-                    amount = entry.uberEarnings
-                )
-            }
-            
-            if (entry.yangoEarnings > 0) {
-                EarningsRow(
-                    label = "Yango",
-                    amount = entry.yangoEarnings
-                )
-            }
-            
-            if (entry.privateJobsEarnings > 0) {
-                EarningsRow(
-                    label = "Private Jobs",
-                    amount = entry.privateJobsEarnings
-                )
-            }
+            entry.earnings
+                .filter { it.totalAmount > 0 }
+                .forEach { earning ->
+                    EarningsRow(
+                        label = earning.provider.ifBlank { "Earnings" },
+                        amount = earning.totalAmount
+                    )
+                }
             
             // Total
             Divider(modifier = Modifier.padding(vertical = 4.dp))
@@ -197,6 +197,14 @@ private fun EntryCard(
                 )
             }
         }
+    }
+}
+
+private fun formatOdometer(value: Double): String {
+    return if (value % 1.0 == 0.0) {
+        value.toLong().toString()
+    } else {
+        String.format(Locale.getDefault(), "%.1f", value)
     }
 }
 

--- a/app/src/main/java/com/fleetmanager/ui/screens/analytics/utils/MockDataProvider.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/analytics/utils/MockDataProvider.kt
@@ -1,6 +1,7 @@
 package com.fleetmanager.ui.screens.analytics.utils
 
 import com.fleetmanager.domain.model.DailyEntry
+import com.fleetmanager.domain.model.EarningEntry
 import com.fleetmanager.domain.model.Expense
 import com.fleetmanager.domain.model.ExpenseType
 import com.fleetmanager.ui.screens.analytics.model.*
@@ -101,6 +102,14 @@ object MockDataProvider {
         val vehicle = vehicleNames.random()
         val dateAsDate = Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant())
 
+        val earnings = buildList {
+            generateRandomEarning("Uber", 0.3)?.let { add(it) }
+            generateRandomEarning("Careem", 0.4)?.let { add(it) }
+            generateRandomEarning("Private", 0.6)?.let { add(it) }
+        }.ifEmpty {
+            listOf(generateRandomEarning("Uber", probability = 1.0)!!)
+        }
+
         return DailyEntry(
             id = UUID.randomUUID().toString(),
             userId = "mock_user",
@@ -109,13 +118,31 @@ object MockDataProvider {
             driverName = driver,
             vehicleId = vehicle.lowercase().replace(" ", "_").replace("'", ""),
             vehicle = vehicle,
-            uberEarnings = if (Random.nextDouble() > 0.3) Random.nextDouble() * 200 + 50 else 0.0,
-            yangoEarnings = if (Random.nextDouble() > 0.4) Random.nextDouble() * 150 + 30 else 0.0,
-            privateJobsEarnings = if (Random.nextDouble() > 0.6) Random.nextDouble() * 100 + 20 else 0.0,
+            earnings = earnings,
             notes = "Mock entry for $date",
             isSynced = true,
             createdAt = dateAsDate,
             updatedAt = dateAsDate
+        )
+    }
+
+    private fun generateRandomEarning(provider: String, probability: Double): EarningEntry? {
+        if (Random.nextDouble() > probability) {
+            return null
+        }
+
+        val base = Random.nextDouble() * 200 + 50
+        val cashPortion = base * Random.nextDouble(0.0, 0.3)
+        val tips = base * Random.nextDouble(0.0, 0.1)
+        val card = base - cashPortion
+
+        return EarningEntry(
+            provider = provider,
+            cardEarnings = card,
+            cashEarnings = cashPortion,
+            tips = tips,
+            tripCount = Random.nextInt(1, 12),
+            hoursOnline = Random.nextDouble(2.0, 10.0)
         )
     }
 

--- a/app/src/main/java/com/fleetmanager/ui/screens/entry/AddEntryScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/entry/AddEntryScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -188,31 +189,136 @@ fun AddEntryScreen(
                 }
             }
             
-            // Earnings fields
             OutlinedTextField(
-                value = uiState.uberEarnings,
-                onValueChange = viewModel::updateUberEarnings,
-                label = { Text(stringResource(R.string.uber_earnings)) },
+                value = uiState.odometer,
+                onValueChange = viewModel::updateOdometer,
+                label = { Text(stringResource(R.string.odometer)) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                isError = uiState.odometerError != null
             )
-            
-            OutlinedTextField(
-                value = uiState.yangoEarnings,
-                onValueChange = viewModel::updateYangoEarnings,
-                label = { Text(stringResource(R.string.yango_earnings)) },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                modifier = Modifier.fillMaxWidth()
+
+            uiState.odometerError?.let { error ->
+                Text(
+                    text = error,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+
+            Text(
+                text = stringResource(R.string.earnings),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
             )
-            
-            OutlinedTextField(
-                value = uiState.privateJobsEarnings,
-                onValueChange = viewModel::updatePrivateJobsEarnings,
-                label = { Text(stringResource(R.string.private_jobs)) },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+
+            uiState.earnings.forEach { earning ->
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            OutlinedTextField(
+                                value = earning.provider,
+                                onValueChange = { viewModel.updateEarningProvider(earning.id, it) },
+                                label = { Text(stringResource(R.string.provider)) },
+                                modifier = Modifier.weight(1f)
+                            )
+
+                            if (uiState.earnings.size > 1) {
+                                IconButton(onClick = { viewModel.removeEarningInput(earning.id) }) {
+                                    Icon(
+                                        imageVector = Icons.Default.Close,
+                                        contentDescription = stringResource(R.string.remove_provider)
+                                    )
+                                }
+                            }
+                        }
+
+                        if (earning.providerError != null) {
+                            Text(
+                                text = earning.providerError,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error
+                            )
+                        }
+
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            OutlinedTextField(
+                                value = earning.card,
+                                onValueChange = { viewModel.updateEarningCard(earning.id, it) },
+                                label = { Text(stringResource(R.string.card_earnings)) },
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                                modifier = Modifier.weight(1f)
+                            )
+
+                            OutlinedTextField(
+                                value = earning.cash,
+                                onValueChange = { viewModel.updateEarningCash(earning.id, it) },
+                                label = { Text(stringResource(R.string.cash_earnings)) },
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                                modifier = Modifier.weight(1f)
+                            )
+
+                            OutlinedTextField(
+                                value = earning.tips,
+                                onValueChange = { viewModel.updateEarningTips(earning.id, it) },
+                                label = { Text(stringResource(R.string.tips)) },
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
+
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            OutlinedTextField(
+                                value = earning.tripCount,
+                                onValueChange = { viewModel.updateEarningTripCount(earning.id, it) },
+                                label = { Text(stringResource(R.string.trip_count)) },
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                modifier = Modifier.weight(1f)
+                            )
+
+                            OutlinedTextField(
+                                value = earning.hoursOnline,
+                                onValueChange = { viewModel.updateEarningHoursOnline(earning.id, it) },
+                                label = { Text(stringResource(R.string.hours_online)) },
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
+
+                        earning.amountError?.let { error ->
+                            Text(
+                                text = error,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error
+                            )
+                        }
+                    }
+                }
+            }
+
+            OutlinedButton(
+                onClick = viewModel::addEarningInput,
                 modifier = Modifier.fillMaxWidth()
-            )
-            
+            ) {
+                Text(stringResource(R.string.add_provider))
+            }
+
             // Notes field
             OutlinedTextField(
                 value = uiState.notes,

--- a/app/src/main/java/com/fleetmanager/ui/viewmodel/ReportViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/viewmodel/ReportViewModel.kt
@@ -292,22 +292,10 @@ class ReportViewModel @Inject constructor(
                     null,
                     EntryTypeFilter.ALL
                 )
-                DashboardShortcut.IncomeSource.Uber -> Quadruple(
+                is DashboardShortcut.Provider -> Quadruple(
                     calculateStartOfCurrentMonth(),
                     endOfToday,
-                    "Uber",
-                    EntryTypeFilter.INCOME_ONLY
-                )
-                DashboardShortcut.IncomeSource.Yango -> Quadruple(
-                    calculateStartOfCurrentMonth(),
-                    endOfToday,
-                    "Yango",
-                    EntryTypeFilter.INCOME_ONLY
-                )
-                DashboardShortcut.IncomeSource.Private -> Quadruple(
-                    calculateStartOfCurrentMonth(),
-                    endOfToday,
-                    "Private",
+                    shortcut.name,
                     EntryTypeFilter.INCOME_ONLY
                 )
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,17 @@
     <string name="uber_earnings">Uber Earnings</string>
     <string name="yango_earnings">Yango Earnings</string>
     <string name="private_jobs">Private Jobs</string>
+    <string name="earnings">Earnings</string>
+    <string name="provider">Provider</string>
+    <string name="card_earnings">Card Earnings</string>
+    <string name="cash_earnings">Cash Earnings</string>
+    <string name="tips">Tips</string>
+    <string name="trip_count">Trip Count</string>
+    <string name="hours_online">Hours Online</string>
+    <string name="add_provider">Add Provider</string>
+    <string name="remove_provider">Remove provider</string>
+    <string name="odometer">Odometer</string>
+    <string name="odometer_reading">Odometer: %1$s km</string>
     <string name="notes">Notes</string>
     <string name="date">Date</string>
     <string name="save">Save</string>


### PR DESCRIPTION
## Summary
- introduce dedicated earning models/DTOs for the nested entriesNEW schema, including conversions and validation
- update dashboard aggregation and repository-facing use cases to read provider-agnostic totals from entriesNEW
- refresh entry-related UI and strings to render dynamic provider earnings and optional odometer values across flows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0b5bd0ed48323bec52a66d180f7f4