### PR TITLE
Refactor add entry viewmodel to stateflow

### DIFF
--- a/app/src/main/java/com/fleetmanager/ui/screens/entry/AddEntryScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/entry/AddEntryScreen.kt
@@ -327,7 +327,7 @@ fun AddEntryScreen(
             }
             
             // Error message
-            uiState.errorMessage?.let { error ->
+            uiState.error?.let { error ->
                 if (error.isNotEmpty()) {
                     Card(
                         modifier = Modifier.fillMaxWidth(),
@@ -349,11 +349,11 @@ fun AddEntryScreen(
             val saveButtonLabel = if (uiState.isEditing) R.string.update_entry else R.string.save
             Button(
                 onClick = viewModel::saveEntry,
-                enabled = uiState.canSave && !uiState.isSaving,
+                enabled = uiState.canSave && !uiState.isLoading,
                 modifier = Modifier.fillMaxWidth(),
                 shape = RoundedCornerShape(12.dp)
             ) {
-                if (uiState.isSaving) {
+                if (uiState.isLoading) {
                     CircularProgressIndicator(
                         modifier = Modifier.size(20.dp),
                         strokeWidth = 2.dp,

--- a/app/src/main/java/com/fleetmanager/ui/viewmodel/AddEntryViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/viewmodel/AddEntryViewModel.kt
@@ -37,9 +37,9 @@ data class AddEntryUiState(
     val driverDropdownExpanded: Boolean = false,
     val vehicleDropdownExpanded: Boolean = false,
     val showDatePicker: Boolean = false,
-    val isSaving: Boolean = false,
+    val isLoading: Boolean = false,
     val isSaved: Boolean = false,
-    val errorMessage: String? = null,
+    val error: String? = null,
     val uberEarningsError: String? = null,
     val yangoEarningsError: String? = null,
     val privateJobsEarningsError: String? = null,
@@ -120,7 +120,7 @@ class AddEntryViewModel @Inject constructor(
     private fun loadFirestoreData() {
         executeAsync(
             onError = { error ->
-                updateState { it.copy(errorMessage = "Failed to load data: $error") }
+                updateState { it.copy(error = "Failed to load data: $error") }
             }
         ) {
             combine(
@@ -366,17 +366,17 @@ class AddEntryViewModel @Inject constructor(
 
         if (driverId.isBlank() || vehicleId.isBlank()) {
             updateState {
-                it.copy(errorMessage = "Please select a valid driver and vehicle")
+                it.copy(error = "Please select a valid driver and vehicle")
             }
             return
         }
 
         executeAsync(
-            onLoading = { isLoading ->
-                updateState { it.copy(isSaving = isLoading, errorMessage = null) }
+            onLoading = { loading ->
+                updateState { it.copy(isLoading = loading, error = null) }
             },
-            onError = { error ->
-                updateState { it.copy(isSaving = false, errorMessage = error) }
+            onError = { errorMsg ->
+                updateState { it.copy(isLoading = false, error = errorMsg) }
             }
         ) {
             val now = Date()
@@ -437,13 +437,13 @@ class AddEntryViewModel @Inject constructor(
             val result = saveDailyEntryUseCase(entry, currentState.photoUri, currentState.photoUris)
             result.fold(
                 onSuccess = {
-                    updateState { it.copy(isSaving = false, isSaved = true) }
+                    updateState { it.copy(isLoading = false, isSaved = true) }
                 },
-                onFailure = { error ->
+                onFailure = { errorThrown ->
                     updateState {
                         it.copy(
-                            isSaving = false,
-                            errorMessage = error.message ?: "Failed to save entry"
+                            isLoading = false,
+                            error = errorThrown.message ?: "Failed to save entry"
                         )
                     }
                 }
@@ -453,11 +453,11 @@ class AddEntryViewModel @Inject constructor(
 
     fun loadEntryForEdit(entryId: String) {
         executeAsync(
-            onLoading = { isLoading ->
-                updateState { it.copy(isSaving = false, errorMessage = null) }
+            onLoading = { loading ->
+                updateState { it.copy(isLoading = false, error = null) }
             },
-            onError = { error ->
-                updateState { it.copy(errorMessage = error) }
+            onError = { errorMsg ->
+                updateState { it.copy(error = errorMsg) }
             }
         ) {
             getEntryByIdUseCase(entryId)
@@ -478,12 +478,12 @@ class AddEntryViewModel @Inject constructor(
                             notes = entry.notes,
                             existingPhotoUrls = entry.photoUrls,
                             createdAt = entry.createdAt,
-                            errorMessage = null,
+                            error = null,
                             isSaved = false
                         )
                     }
                 } ?: updateState {
-                it.copy(errorMessage = "Entry not found")
+                it.copy(error = "Entry not found")
             }
         }
     }


### PR DESCRIPTION
Rename `isSaving` to `isLoading` and `errorMessage` to `error` in `AddEntryUiState` and related UI/ViewModel logic to align with specified naming conventions.

---
<a href="https://cursor.com/background-agent?bcId=bc-94b9e09b-5b7e-4f0e-91c6-b57d41d7bb69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-94b9e09b-5b7e-4f0e-91c6-b57d41d7bb69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

