### PR TITLE
Add provider breakdown inputs for income entries

### DIFF
--- a/app/src/main/java/com/fleetmanager/data/dto/DailyEntryDto.kt
+++ b/app/src/main/java/com/fleetmanager/data/dto/DailyEntryDto.kt
@@ -24,6 +24,7 @@ data class DailyEntryDto(
     val localPhotoPath: String? = null,
     val photoUrls: List<String> = emptyList(),
     val localPhotoPaths: List<String> = emptyList(),
+    val odometer: Double? = null,
     val isSynced: Boolean = false,
     val createdAt: Date = Date(),
     val updatedAt: Date = Date()

--- a/app/src/main/java/com/fleetmanager/data/local/Converters.kt
+++ b/app/src/main/java/com/fleetmanager/data/local/Converters.kt
@@ -51,7 +51,14 @@ class Converters {
                 providers.add(
                     ProviderEarning(
                         type = type,
-                        amount = obj.optDouble("amount", 0.0),
+                        amount = obj.optDouble("amount", 0.0).takeIf { it > 0 }
+                            ?: (obj.optDouble("cardAmount", obj.optDouble("card", 0.0))
+                            + obj.optDouble("cashAmount", obj.optDouble("cash", 0.0))
+                            + obj.optDouble("tipsAmount", obj.optDouble("tips", 0.0))),
+                        cardAmount = obj.optDouble("cardAmount", obj.optDouble("card", 0.0)),
+                        cashAmount = obj.optDouble("cashAmount", obj.optDouble("cash", 0.0)),
+                        tipsAmount = obj.optDouble("tipsAmount", obj.optDouble("tips", 0.0)),
+                        hoursOnline = obj.optDouble("hoursOnline", Double.NaN).takeUnless { it.isNaN() },
                         currency = obj.optString("currency", "AED"),
                         tripsCount = if (obj.has("tripsCount")) obj.optInt("tripsCount") else null,
                         meta = null // Keep simple
@@ -78,8 +85,15 @@ class Converters {
                 try {
                     val obj = JSONObject()
                     obj.put("type", provider.type.name)
-                    obj.put("amount", provider.amount)
+                    obj.put("amount", provider.totalAmount)
                     obj.put("currency", provider.currency)
+                    obj.put("cardAmount", provider.cardAmount)
+                    obj.put("card", provider.cardAmount)
+                    obj.put("cashAmount", provider.cashAmount)
+                    obj.put("cash", provider.cashAmount)
+                    obj.put("tipsAmount", provider.tipsAmount)
+                    obj.put("tips", provider.tipsAmount)
+                    provider.hoursOnline?.let { obj.put("hoursOnline", it) }
                     provider.tripsCount?.let { obj.put("tripsCount", it) }
                     jsonArray.put(obj)
                     successCount++

--- a/app/src/main/java/com/fleetmanager/data/local/FleetManagerDatabase.kt
+++ b/app/src/main/java/com/fleetmanager/data/local/FleetManagerDatabase.kt
@@ -16,7 +16,7 @@ import com.fleetmanager.data.dto.ExpenseDto
 
 @Database(
     entities = [DailyEntryDto::class, DriverDto::class, VehicleDto::class, ExpenseDto::class],
-    version = 8,
+    version = 9,
     exportSchema = false
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/fleetmanager/data/mapper/DailyEntryMapper.kt
+++ b/app/src/main/java/com/fleetmanager/data/mapper/DailyEntryMapper.kt
@@ -19,6 +19,7 @@ object DailyEntryMapper {
             providers = dto.providers,
             notes = dto.notes,
             photoUrls = dto.photoUrls,
+            odometer = dto.odometer,
             isSynced = dto.isSynced,
             createdAt = dto.createdAt,
             updatedAt = dto.updatedAt
@@ -35,6 +36,7 @@ object DailyEntryMapper {
             providers = domain.providers,
             notes = domain.notes,
             photoUrls = domain.photoUrls,
+            odometer = domain.odometer,
             isSynced = domain.isSynced,
             createdAt = domain.createdAt,
             updatedAt = domain.updatedAt

--- a/app/src/main/java/com/fleetmanager/data/remote/FirestoreService.kt
+++ b/app/src/main/java/com/fleetmanager/data/remote/FirestoreService.kt
@@ -163,14 +163,15 @@ class FirestoreService @Inject constructor(
                         com.fleetmanager.domain.model.ProviderType.PRIVATE -> "Private"
                         com.fleetmanager.domain.model.ProviderType.OTHER -> "Other"
                     }
-                    
+
                     hashMapOf<String, Any?>(
-                        "provider" to providerName,      // Use "provider" not "type"
-                        "card" to provider.amount,        // Use "card" not "amount"
-                        "cash" to 0.0,                    // Include cash (even if zero)
-                        "tips" to 0.0,                    // Include tips (even if zero)
-                        "trips" to (provider.tripsCount ?: 0),  // Include trips
-                        "hoursOnline" to 0.0              // Include hoursOnline (even if zero)
+                        "provider" to providerName,
+                        "card" to provider.cardAmount,
+                        "cash" to provider.cashAmount,
+                        "tips" to provider.tipsAmount,
+                        "trips" to (provider.tripsCount ?: 0),
+                        "hoursOnline" to (provider.hoursOnline ?: 0.0),
+                        "amount" to provider.totalAmount
                     )
                 },
                 "notes" to entry.notes,
@@ -180,7 +181,7 @@ class FirestoreService @Inject constructor(
                 "updatedAt" to entry.updatedAt,
                 "valid" to true,                          // Add validation fields
                 "validationErrors" to emptyList<String>(),
-                "odometer" to null                        // Add odometer field (null)
+                "odometer" to entry.odometer
             )
             
             getCollection(FirestoreCollections.ENTRIES)
@@ -973,6 +974,7 @@ private fun parseDailyEntryFromDocument(document: com.google.firebase.firestore.
         val vehicleId = document.getString("vehicleId") ?: ""
         val notes = document.getString("notes") ?: ""
         val isSynced = document.getBoolean("isSynced") ?: true
+        val odometer = document.getDouble("odometer")
         
         // Parse date
         val date = document.getDate("date") ?: java.util.Date()
@@ -994,6 +996,7 @@ private fun parseDailyEntryFromDocument(document: com.google.firebase.firestore.
             providers = providers,
             notes = notes,
             photoUrls = photoUrls,
+            odometer = odometer,
             isSynced = isSynced,
             date = date,
             createdAt = createdAt,
@@ -1033,21 +1036,34 @@ private fun parseProvidersFromFirestore(document: com.google.firebase.firestore.
                 }
                 
                 // Amount is in "card" field (not "amount")
-                val cardAmount = (earningMap["card"] as? Number)?.toDouble() ?: 0.0
-                val cashAmount = (earningMap["cash"] as? Number)?.toDouble() ?: 0.0
-                val tips = (earningMap["tips"] as? Number)?.toDouble() ?: 0.0
-                
-                // Total amount = card + cash + tips
+                val storedCard = (earningMap["card"] as? Number)?.toDouble() ?: 0.0
+                val storedCash = (earningMap["cash"] as? Number)?.toDouble() ?: 0.0
+                val storedTips = (earningMap["tips"] as? Number)?.toDouble() ?: 0.0
+                val storedAmount = (earningMap["amount"] as? Number)?.toDouble()
+                val hoursOnline = (earningMap["hoursOnline"] as? Number)?.toDouble()
+
+                val cardAmount = when {
+                    storedCard > 0.0 -> storedCard
+                    storedCard == 0.0 && storedCash == 0.0 && storedTips == 0.0 && (storedAmount ?: 0.0) > 0.0 ->
+                        storedAmount ?: 0.0
+                    else -> storedCard
+                }
+                val cashAmount = storedCash
+                val tips = storedTips
+
                 val totalAmount = cardAmount + cashAmount + tips
-                
-                // Get trips count
+
                 val tripsCount = (earningMap["trips"] as? Number)?.toInt()
-                
+
                 if (totalAmount > 0) {
                     providers.add(
                         com.fleetmanager.domain.model.ProviderEarning(
                             type = type,
                             amount = totalAmount,
+                            cardAmount = cardAmount,
+                            cashAmount = cashAmount,
+                            tipsAmount = tips,
+                            hoursOnline = hoursOnline,
                             currency = "AED",
                             tripsCount = tripsCount,
                             meta = null
@@ -1071,6 +1087,7 @@ private fun parseProvidersFromFirestore(document: com.google.firebase.firestore.
                 com.fleetmanager.domain.model.ProviderEarning(
                     type = com.fleetmanager.domain.model.ProviderType.UBER,
                     amount = uberEarnings,
+                    cardAmount = uberEarnings,
                     currency = "AED"
                 )
             )
@@ -1081,6 +1098,7 @@ private fun parseProvidersFromFirestore(document: com.google.firebase.firestore.
                 com.fleetmanager.domain.model.ProviderEarning(
                     type = com.fleetmanager.domain.model.ProviderType.CAREEM,
                     amount = careemEarnings,
+                    cardAmount = careemEarnings,
                     currency = "AED"
                 )
             )
@@ -1091,6 +1109,7 @@ private fun parseProvidersFromFirestore(document: com.google.firebase.firestore.
                 com.fleetmanager.domain.model.ProviderEarning(
                     type = com.fleetmanager.domain.model.ProviderType.YANGO,
                     amount = yangoEarnings,
+                    cardAmount = yangoEarnings,
                     currency = "AED"
                 )
             )
@@ -1101,6 +1120,7 @@ private fun parseProvidersFromFirestore(document: com.google.firebase.firestore.
                 com.fleetmanager.domain.model.ProviderEarning(
                     type = com.fleetmanager.domain.model.ProviderType.PRIVATE,
                     amount = privateJobsEarnings,
+                    cardAmount = privateJobsEarnings,
                     currency = "AED"
                 )
             )

--- a/app/src/main/java/com/fleetmanager/domain/model/DailyEntry.kt
+++ b/app/src/main/java/com/fleetmanager/domain/model/DailyEntry.kt
@@ -32,21 +32,52 @@ enum class ProviderType {
 data class ProviderEarning(
     @get:PropertyName("type")
     val type: ProviderType = ProviderType.OTHER,
-    
+
     @get:PropertyName("amount")
     val amount: Double = 0.0,
-    
+
+    @get:PropertyName("card")
+    val cardAmount: Double = 0.0,
+
+    @get:PropertyName("cash")
+    val cashAmount: Double = 0.0,
+
+    @get:PropertyName("tips")
+    val tipsAmount: Double = 0.0,
+
+    @get:PropertyName("hoursOnline")
+    val hoursOnline: Double? = null,
+
     @get:PropertyName("currency")
     val currency: String = "AED",
-    
+
     @get:PropertyName("tripsCount")
     val tripsCount: Int? = null,
-    
+
     @get:PropertyName("meta")
     val meta: Map<String, Any?>? = null
 ) {
     // No-arg constructor for Firestore
-    constructor() : this(ProviderType.OTHER, 0.0, "AED", null, null)
+    constructor() : this(
+        type = ProviderType.OTHER,
+        amount = 0.0,
+        cardAmount = 0.0,
+        cashAmount = 0.0,
+        tipsAmount = 0.0,
+        hoursOnline = null,
+        currency = "AED",
+        tripsCount = null,
+        meta = null
+    )
+
+    val hasBreakdown: Boolean
+        get() = cardAmount > 0.0 || cashAmount > 0.0 || tipsAmount > 0.0
+
+    val totalAmount: Double
+        get() = when {
+            hasBreakdown -> cardAmount + cashAmount + tipsAmount
+            else -> amount
+        }
 }
 
 /**
@@ -83,10 +114,13 @@ data class DailyEntry(
     
     @get:PropertyName("notes")
     val notes: String = "",
-    
+
     @get:PropertyName("photos")
     val photoUrls: List<String> = emptyList(),
-    
+
+    @get:PropertyName("odometer")
+    val odometer: Double? = null,
+
     @get:PropertyName("isSynced")
     val isSynced: Boolean = false,
     
@@ -100,7 +134,7 @@ data class DailyEntry(
      * Calculate total earnings from all providers
      */
     val totalEarnings: Double
-        get() = providers.sumOf { it.amount }
+        get() = providers.sumOf { it.totalAmount }
 
     /**
      * Get earnings amount for specific provider type(s)
@@ -108,7 +142,7 @@ data class DailyEntry(
     fun amountFor(vararg types: ProviderType): Double {
         return providers
             .filter { it.type in types }
-            .sumOf { it.amount }
+            .sumOf { it.totalAmount }
     }
 
     /**
@@ -140,32 +174,75 @@ data class DailyEntry(
         get() = amountFor(ProviderType.PRIVATE)
 
     fun isValid(): Boolean {
+        val hasValidProvider = providers.any { it.totalAmount > 0.0 }
+        val providersValid = providers.all { provider ->
+            val total = provider.totalAmount
+            total >= 0 && total <= 999999.99 &&
+                    provider.cashAmount >= 0 &&
+                    provider.cardAmount >= 0 &&
+                    provider.tipsAmount >= 0 &&
+                    (provider.hoursOnline == null || provider.hoursOnline >= 0)
+        }
+
+        val odometerValid = odometer == null || odometer >= 0
+
         return id.isNotBlank() &&
                 driverId.isNotBlank() &&
                 vehicleId.isNotBlank() &&
-                providers.all { it.amount >= 0 && it.amount <= 999999.99 } &&
+                providersValid &&
+                hasValidProvider &&
+                odometerValid &&
                 notes.length <= 5000
     }
 
     fun getValidationErrors(): List<String> {
         val errors = mutableListOf<String>()
-        
+
         if (id.isBlank()) errors.add("ID cannot be blank")
         if (driverId.isBlank()) errors.add("Driver ID cannot be blank")
         if (vehicleId.isBlank()) errors.add("Vehicle ID cannot be blank")
-        
+
+        val hasProvider = providers.any { it.totalAmount > 0.0 }
+        if (!hasProvider) {
+            errors.add("At least one provider must have earnings")
+        }
+
         providers.forEach { provider ->
-            if (provider.amount < 0) {
+            val total = provider.totalAmount
+            if (total < 0) {
                 errors.add("${provider.type.name} earnings cannot be negative")
             }
-            if (provider.amount > 999999.99) {
+            if (total > 999999.99) {
                 errors.add("${provider.type.name} earnings is too large")
             }
+            if (provider.cashAmount < 0) {
+                errors.add("${provider.type.name} cash earnings cannot be negative")
+            }
+            if (provider.cardAmount < 0) {
+                errors.add("${provider.type.name} card earnings cannot be negative")
+            }
+            if (provider.tipsAmount < 0) {
+                errors.add("${provider.type.name} tips cannot be negative")
+            }
+            provider.hoursOnline?.let { hours ->
+                if (hours < 0) {
+                    errors.add("${provider.type.name} hours online cannot be negative")
+                }
+            }
         }
-        
+
         if (notes.length > 5000) errors.add("Notes too long (max 5000 characters)")
+        odometer?.let { value ->
+            if (value < 0) {
+                errors.add("Odometer cannot be negative")
+            }
+        }
 
         return errors
+    }
+
+    fun providerFor(type: ProviderType): ProviderEarning? {
+        return providers.firstOrNull { it.type == type }
     }
 
     fun withResolvedDisplayData(

--- a/app/src/main/java/com/fleetmanager/domain/model/DailyEntry.kt
+++ b/app/src/main/java/com/fleetmanager/domain/model/DailyEntry.kt
@@ -181,7 +181,8 @@ data class DailyEntry(
                     provider.cashAmount >= 0 &&
                     provider.cardAmount >= 0 &&
                     provider.tipsAmount >= 0 &&
-                    (provider.hoursOnline == null || provider.hoursOnline >= 0)
+                    (provider.hoursOnline == null || provider.hoursOnline >= 0) &&
+                    (provider.tripsCount == null || (provider.tripsCount >= 0 && provider.tripsCount <= 500))
         }
 
         val odometerValid = odometer == null || odometer >= 0
@@ -227,6 +228,15 @@ data class DailyEntry(
             provider.hoursOnline?.let { hours ->
                 if (hours < 0) {
                     errors.add("${provider.type.name} hours online cannot be negative")
+                }
+            }
+
+            provider.tripsCount?.let { trips ->
+                if (trips < 0) {
+                    errors.add("${provider.type.name} trips cannot be negative")
+                }
+                if (trips > 500) {
+                    errors.add("${provider.type.name} trips seems too high")
                 }
             }
         }

--- a/app/src/main/java/com/fleetmanager/domain/usecase/SaveDailyEntryUseCase.kt
+++ b/app/src/main/java/com/fleetmanager/domain/usecase/SaveDailyEntryUseCase.kt
@@ -43,9 +43,8 @@ class SaveDailyEntryUseCase @Inject constructor(
             { validator.validateText(entry.id, "Entry ID") },
             { validator.validateText(entry.driverId, "Driver ID") },
             { validator.validateText(entry.vehicleId, "Vehicle ID") },
-            { validator.validateEarnings(entry.uberEarnings.toString(), "Uber earnings") },
-            { validator.validateEarnings(entry.yangoEarnings.toString(), "Yango earnings") },
-            { validator.validateEarnings(entry.privateJobsEarnings.toString(), "Private jobs earnings") },
+            { validator.validateProviderEarnings(entry.providers) },
+            { validator.validateOdometer(entry.odometer) },
             { validator.validateNotes(entry.notes) },
             { validator.validateDate(entry.date) }
         )

--- a/app/src/main/java/com/fleetmanager/domain/validation/InputValidator.kt
+++ b/app/src/main/java/com/fleetmanager/domain/validation/InputValidator.kt
@@ -150,6 +150,29 @@ class InputValidator @Inject constructor() {
         return ValidationResult.Success
     }
 
+    fun validateOptionalTrips(trips: String?, fieldName: String = "Trips"): ValidationResult {
+        if (trips.isNullOrBlank()) {
+            return ValidationResult.Success
+        }
+
+        val sanitized = sanitizeIntegerInput(trips)
+        val value = sanitized.toIntOrNull()
+
+        if (value == null) {
+            return ValidationResult.Error("$fieldName must be a whole number")
+        }
+
+        if (value < 0) {
+            return ValidationResult.Error("$fieldName cannot be negative")
+        }
+
+        if (value > 500) {
+            return ValidationResult.Error("$fieldName seems too high")
+        }
+
+        return ValidationResult.Success
+    }
+
     fun validateOdometer(value: Double?): ValidationResult {
         val odometer = value ?: return ValidationResult.Success
 
@@ -189,6 +212,15 @@ class InputValidator @Inject constructor() {
                 }
                 if (hours > 48) {
                     return ValidationResult.Error("${provider.type.name} hours online seems too high")
+                }
+            }
+
+            provider.tripsCount?.let { trips ->
+                if (trips < 0) {
+                    return ValidationResult.Error("${provider.type.name} trips cannot be negative")
+                }
+                if (trips > 500) {
+                    return ValidationResult.Error("${provider.type.name} trips seems too high")
                 }
             }
         }
@@ -339,7 +371,14 @@ class InputValidator @Inject constructor() {
                 }
             }
     }
-    
+
+    fun sanitizeIntegerInput(input: String?): String {
+        if (input.isNullOrBlank()) return ""
+
+        return input.trim()
+    }
+
+
     /**
      * Validates multiple fields and returns the first error found.
      */

--- a/app/src/main/java/com/fleetmanager/domain/validation/InputValidator.kt
+++ b/app/src/main/java/com/fleetmanager/domain/validation/InputValidator.kt
@@ -1,5 +1,6 @@
 package com.fleetmanager.domain.validation
 
+import com.fleetmanager.domain.model.ProviderEarning
 import java.util.*
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -79,6 +80,117 @@ class InputValidator @Inject constructor() {
 
         if (value > 999999.99) {
             return ValidationResult.Error("$fieldName is too large")
+        }
+
+        return ValidationResult.Success
+    }
+
+    fun validateOptionalEarnings(amount: String?, fieldName: String): ValidationResult {
+        if (amount.isNullOrBlank()) {
+            return ValidationResult.Success
+        }
+
+        val sanitized = sanitizeNumericInput(amount)
+        val value = sanitized.toDoubleOrNull()
+
+        if (value == null) {
+            return ValidationResult.Error("$fieldName must be a valid number")
+        }
+
+        if (value < 0) {
+            return ValidationResult.Error("$fieldName cannot be negative")
+        }
+
+        if (value > 999999.99) {
+            return ValidationResult.Error("$fieldName is too large")
+        }
+
+        return ValidationResult.Success
+    }
+
+    fun validateOptionalDecimal(amount: String?, fieldName: String): ValidationResult {
+        if (amount.isNullOrBlank()) {
+            return ValidationResult.Success
+        }
+
+        val sanitized = sanitizeNumericInput(amount)
+        val value = sanitized.toDoubleOrNull()
+
+        if (value == null) {
+            return ValidationResult.Error("$fieldName must be a valid number")
+        }
+
+        if (value < 0) {
+            return ValidationResult.Error("$fieldName cannot be negative")
+        }
+
+        return ValidationResult.Success
+    }
+
+    fun validateOptionalHours(hours: String?, fieldName: String = "Hours online"): ValidationResult {
+        if (hours.isNullOrBlank()) {
+            return ValidationResult.Success
+        }
+
+        val sanitized = sanitizeNumericInput(hours)
+        val value = sanitized.toDoubleOrNull()
+
+        if (value == null) {
+            return ValidationResult.Error("$fieldName must be a valid number")
+        }
+
+        if (value < 0) {
+            return ValidationResult.Error("$fieldName cannot be negative")
+        }
+
+        if (value > 48) {
+            return ValidationResult.Error("$fieldName seems too high")
+        }
+
+        return ValidationResult.Success
+    }
+
+    fun validateOdometer(value: Double?): ValidationResult {
+        val odometer = value ?: return ValidationResult.Success
+
+        if (odometer < 0) {
+            return ValidationResult.Error("Odometer cannot be negative")
+        }
+
+        if (odometer > 9_999_999) {
+            return ValidationResult.Error("Odometer value is too large")
+        }
+
+        return ValidationResult.Success
+    }
+
+    fun validateProviderEarnings(providers: List<ProviderEarning>): ValidationResult {
+        if (providers.isEmpty()) {
+            return ValidationResult.Error("At least one provider must have earnings")
+        }
+
+        providers.forEach { provider ->
+            val total = provider.totalAmount
+            if (total <= 0) {
+                return ValidationResult.Error("${provider.type.name} earnings must be greater than 0")
+            }
+
+            if (total > 999999.99) {
+                return ValidationResult.Error("${provider.type.name} earnings is too large")
+            }
+
+            if (provider.cashAmount < 0 || provider.cardAmount < 0 || provider.tipsAmount < 0) {
+                return ValidationResult.Error("${provider.type.name} earnings cannot be negative")
+            }
+
+            provider.hoursOnline?.let { hours ->
+                if (hours < 0) {
+                    return ValidationResult.Error("${provider.type.name} hours online cannot be negative")
+                }
+                if (hours > 48) {
+                    return ValidationResult.Error("${provider.type.name} hours online seems too high")
+                }
+            }
         }
 
         return ValidationResult.Success

--- a/app/src/main/java/com/fleetmanager/ui/screens/entry/AddEntryScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/entry/AddEntryScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.DateRange
@@ -211,6 +212,7 @@ fun AddEntryScreen(
                 title = stringResource(R.string.provider_section, stringResource(R.string.uber)),
                 providerState = uiState.uberInput,
                 onHoursChange = { viewModel.updateProviderHours(ProviderType.UBER, it) },
+                onTripsChange = { viewModel.updateProviderTrips(ProviderType.UBER, it) },
                 onCashChange = { viewModel.updateProviderCash(ProviderType.UBER, it) },
                 onCardChange = { viewModel.updateProviderCard(ProviderType.UBER, it) },
                 onTipsChange = { viewModel.updateProviderTips(ProviderType.UBER, it) }
@@ -220,6 +222,7 @@ fun AddEntryScreen(
                 title = stringResource(R.string.provider_section, stringResource(R.string.yango)),
                 providerState = uiState.yangoInput,
                 onHoursChange = { viewModel.updateProviderHours(ProviderType.YANGO, it) },
+                onTripsChange = { viewModel.updateProviderTrips(ProviderType.YANGO, it) },
                 onCashChange = { viewModel.updateProviderCash(ProviderType.YANGO, it) },
                 onCardChange = { viewModel.updateProviderCard(ProviderType.YANGO, it) },
                 onTipsChange = { viewModel.updateProviderTips(ProviderType.YANGO, it) }
@@ -229,6 +232,7 @@ fun AddEntryScreen(
                 title = stringResource(R.string.provider_section, stringResource(R.string.private_jobs)),
                 providerState = uiState.privateInput,
                 onHoursChange = { viewModel.updateProviderHours(ProviderType.PRIVATE, it) },
+                onTripsChange = { viewModel.updateProviderTrips(ProviderType.PRIVATE, it) },
                 onCashChange = { viewModel.updateProviderCash(ProviderType.PRIVATE, it) },
                 onCardChange = { viewModel.updateProviderCard(ProviderType.PRIVATE, it) },
                 onTipsChange = { viewModel.updateProviderTips(ProviderType.PRIVATE, it) }
@@ -433,42 +437,72 @@ private fun ProviderEarningsCard(
     title: String,
     providerState: ProviderInputState,
     onHoursChange: (String) -> Unit,
+    onTripsChange: (String) -> Unit,
     onCashChange: (String) -> Unit,
     onCardChange: (String) -> Unit,
     onTipsChange: (String) -> Unit,
 ) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(12.dp)
+    val shape = RoundedCornerShape(16.dp)
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .shadow(8.dp, shape = shape, clip = false)
+            .clip(shape),
+        color = MaterialTheme.colorScheme.surface,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        shape = shape
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text(
                 text = title,
-                style = MaterialTheme.typography.titleSmall
+                style = MaterialTheme.typography.titleMedium
             )
 
-            OutlinedTextField(
-                value = providerState.hoursOnline,
-                onValueChange = onHoursChange,
-                label = { Text(stringResource(R.string.hours_online)) },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                modifier = Modifier.fillMaxWidth(),
-                isError = providerState.hoursOnlineError != null,
-                supportingText = {
-                    providerState.hoursOnlineError?.let { error ->
-                        Text(
-                            text = error,
-                            color = MaterialTheme.colorScheme.error,
-                            style = MaterialTheme.typography.bodySmall
-                        )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                OutlinedTextField(
+                    value = providerState.hoursOnline,
+                    onValueChange = onHoursChange,
+                    label = { Text(stringResource(R.string.hours_online)) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    modifier = Modifier.weight(1f),
+                    isError = providerState.hoursOnlineError != null,
+                    supportingText = {
+                        providerState.hoursOnlineError?.let { error ->
+                            Text(
+                                text = error,
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
                     }
-                }
-            )
+                )
+
+                OutlinedTextField(
+                    value = providerState.trips,
+                    onValueChange = onTripsChange,
+                    label = { Text(stringResource(R.string.trips)) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.weight(1f),
+                    isError = providerState.tripsError != null,
+                    supportingText = {
+                        providerState.tripsError?.let { error ->
+                            Text(
+                                text = error,
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                    }
+                )
+            }
 
             Row(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -511,30 +545,23 @@ private fun ProviderEarningsCard(
                 )
             }
 
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                OutlinedTextField(
-                    value = providerState.tips,
-                    onValueChange = onTipsChange,
-                    label = { Text(stringResource(R.string.tips)) },
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                    modifier = Modifier.weight(1f),
-                    isError = providerState.tipsError != null,
-                    supportingText = {
-                        providerState.tipsError?.let { error ->
-                            Text(
-                                text = error,
-                                color = MaterialTheme.colorScheme.error,
-                                style = MaterialTheme.typography.bodySmall
-                            )
-                        }
+            OutlinedTextField(
+                value = providerState.tips,
+                onValueChange = onTipsChange,
+                label = { Text(stringResource(R.string.tips)) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                modifier = Modifier.fillMaxWidth(),
+                isError = providerState.tipsError != null,
+                supportingText = {
+                    providerState.tipsError?.let { error ->
+                        Text(
+                            text = error,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall
+                        )
                     }
-                )
-
-                Spacer(modifier = Modifier.weight(1f))
-            }
+                }
+            )
         }
     }
 }

--- a/app/src/main/java/com/fleetmanager/ui/screens/entry/AddEntryScreen.kt
+++ b/app/src/main/java/com/fleetmanager/ui/screens/entry/AddEntryScreen.kt
@@ -4,29 +4,30 @@ import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.ui.draw.clip
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.fleetmanager.domain.model.ProviderType
 import com.fleetmanager.ui.viewmodel.AddEntryViewModel
+import com.fleetmanager.ui.viewmodel.ProviderInputState
 import com.fleetmanager.ui.components.DriverInputComponent
 import com.fleetmanager.ui.components.PhotoGalleryGrid
 import coil.compose.AsyncImage
@@ -44,8 +45,6 @@ fun AddEntryScreen(
     viewModel: AddEntryViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    val context = LocalContext.current
-    
     val multiplePhotoPickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickMultipleVisualMedia(maxItems = 5)
     ) { uris ->
@@ -189,38 +188,77 @@ fun AddEntryScreen(
                 }
             }
             
-            // Earnings fields
+            // Odometer field
             OutlinedTextField(
-                value = uiState.uberEarnings,
-                onValueChange = viewModel::updateUberEarnings,
-                label = { Text(stringResource(R.string.uber_earnings)) },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                modifier = Modifier.fillMaxWidth()
+                value = uiState.odometer,
+                onValueChange = viewModel::updateOdometer,
+                label = { Text(stringResource(R.string.odometer)) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                modifier = Modifier.fillMaxWidth(),
+                isError = uiState.odometerError != null,
+                supportingText = {
+                    uiState.odometerError?.let { error ->
+                        Text(
+                            text = error,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
             )
-            
-            OutlinedTextField(
-                value = uiState.yangoEarnings,
-                onValueChange = viewModel::updateYangoEarnings,
-                label = { Text(stringResource(R.string.yango_earnings)) },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                modifier = Modifier.fillMaxWidth()
+
+            ProviderEarningsCard(
+                title = stringResource(R.string.provider_section, stringResource(R.string.uber)),
+                providerState = uiState.uberInput,
+                onHoursChange = { viewModel.updateProviderHours(ProviderType.UBER, it) },
+                onCashChange = { viewModel.updateProviderCash(ProviderType.UBER, it) },
+                onCardChange = { viewModel.updateProviderCard(ProviderType.UBER, it) },
+                onTipsChange = { viewModel.updateProviderTips(ProviderType.UBER, it) }
             )
-            
-            OutlinedTextField(
-                value = uiState.privateJobsEarnings,
-                onValueChange = viewModel::updatePrivateJobsEarnings,
-                label = { Text(stringResource(R.string.private_jobs)) },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                modifier = Modifier.fillMaxWidth()
+
+            ProviderEarningsCard(
+                title = stringResource(R.string.provider_section, stringResource(R.string.yango)),
+                providerState = uiState.yangoInput,
+                onHoursChange = { viewModel.updateProviderHours(ProviderType.YANGO, it) },
+                onCashChange = { viewModel.updateProviderCash(ProviderType.YANGO, it) },
+                onCardChange = { viewModel.updateProviderCard(ProviderType.YANGO, it) },
+                onTipsChange = { viewModel.updateProviderTips(ProviderType.YANGO, it) }
             )
-            
+
+            ProviderEarningsCard(
+                title = stringResource(R.string.provider_section, stringResource(R.string.private_jobs)),
+                providerState = uiState.privateInput,
+                onHoursChange = { viewModel.updateProviderHours(ProviderType.PRIVATE, it) },
+                onCashChange = { viewModel.updateProviderCash(ProviderType.PRIVATE, it) },
+                onCardChange = { viewModel.updateProviderCard(ProviderType.PRIVATE, it) },
+                onTipsChange = { viewModel.updateProviderTips(ProviderType.PRIVATE, it) }
+            )
+
+            if (!uiState.hasProviderTotals) {
+                Text(
+                    text = stringResource(R.string.add_provider_earnings_hint),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+
             // Notes field
             OutlinedTextField(
                 value = uiState.notes,
                 onValueChange = viewModel::updateNotes,
                 label = { Text(stringResource(R.string.notes)) },
                 maxLines = 3,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                isError = uiState.notesError != null,
+                supportingText = {
+                    uiState.notesError?.let { error ->
+                        Text(
+                            text = error,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
             )
             
             // Photo section
@@ -387,5 +425,116 @@ fun DatePickerDialog(
         }
     ) {
         DatePicker(state = datePickerState)
+    }
+}
+
+@Composable
+private fun ProviderEarningsCard(
+    title: String,
+    providerState: ProviderInputState,
+    onHoursChange: (String) -> Unit,
+    onCashChange: (String) -> Unit,
+    onCardChange: (String) -> Unit,
+    onTipsChange: (String) -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall
+            )
+
+            OutlinedTextField(
+                value = providerState.hoursOnline,
+                onValueChange = onHoursChange,
+                label = { Text(stringResource(R.string.hours_online)) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                modifier = Modifier.fillMaxWidth(),
+                isError = providerState.hoursOnlineError != null,
+                supportingText = {
+                    providerState.hoursOnlineError?.let { error ->
+                        Text(
+                            text = error,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
+            )
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                OutlinedTextField(
+                    value = providerState.cashEarnings,
+                    onValueChange = onCashChange,
+                    label = { Text(stringResource(R.string.cash_earnings)) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    modifier = Modifier.weight(1f),
+                    isError = providerState.cashEarningsError != null,
+                    supportingText = {
+                        providerState.cashEarningsError?.let { error ->
+                            Text(
+                                text = error,
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                    }
+                )
+
+                OutlinedTextField(
+                    value = providerState.cardEarnings,
+                    onValueChange = onCardChange,
+                    label = { Text(stringResource(R.string.card_earnings)) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    modifier = Modifier.weight(1f),
+                    isError = providerState.cardEarningsError != null,
+                    supportingText = {
+                        providerState.cardEarningsError?.let { error ->
+                            Text(
+                                text = error,
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                    }
+                )
+            }
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                OutlinedTextField(
+                    value = providerState.tips,
+                    onValueChange = onTipsChange,
+                    label = { Text(stringResource(R.string.tips)) },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    modifier = Modifier.weight(1f),
+                    isError = providerState.tipsError != null,
+                    supportingText = {
+                        providerState.tipsError?.let { error ->
+                            Text(
+                                text = error,
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                    }
+                )
+
+                Spacer(modifier = Modifier.weight(1f))
+            }
+        }
     }
 }

--- a/app/src/main/java/com/fleetmanager/ui/viewmodel/AddEntryViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/viewmodel/AddEntryViewModel.kt
@@ -40,10 +40,12 @@ data class ProviderInputState(
     val cashEarnings: String = "",
     val cardEarnings: String = "",
     val tips: String = "",
+    val trips: String = "",
     val hoursOnlineError: String? = null,
     val cashEarningsError: String? = null,
     val cardEarningsError: String? = null,
-    val tipsError: String? = null
+    val tipsError: String? = null,
+    val tripsError: String? = null
 ) {
     fun totalAmount(): Double {
         val cash = cashEarnings.toDoubleOrNull() ?: 0.0
@@ -53,7 +55,7 @@ data class ProviderInputState(
     }
 
     fun hasErrors(): Boolean {
-        return listOf(hoursOnlineError, cashEarningsError, cardEarningsError, tipsError).any { it != null }
+        return listOf(hoursOnlineError, cashEarningsError, cardEarningsError, tipsError, tripsError).any { it != null }
     }
 }
 
@@ -297,6 +299,17 @@ class AddEntryViewModel @Inject constructor(
             providerState.copy(
                 tips = sanitized,
                 tipsError = error
+            )
+        }
+    }
+
+    fun updateProviderTrips(providerType: ProviderType, value: String) {
+        val sanitized = validator.sanitizeIntegerInput(value)
+        val error = validator.validateOptionalTrips(sanitized, "${providerType.displayName()} trips").getErrorMessage()
+        updateProviderState(providerType) { providerState ->
+            providerState.copy(
+                trips = sanitized,
+                tripsError = error
             )
         }
     }
@@ -546,6 +559,7 @@ class AddEntryViewModel @Inject constructor(
         }
 
         val hours = hoursOnline.toDoubleOrNull()
+        val tripsCount = trips.toIntOrNull()?.takeIf { it >= 0 }
 
         return ProviderEarning(
             type = type,
@@ -554,7 +568,8 @@ class AddEntryViewModel @Inject constructor(
             cashAmount = cash,
             tipsAmount = tipsValue,
             hoursOnline = hours,
-            currency = "AED"
+            currency = "AED",
+            tripsCount = tripsCount
         )
     }
 
@@ -567,7 +582,8 @@ class AddEntryViewModel @Inject constructor(
             hoursOnline = hoursOnline?.takeIf { it > 0 }?.toInputString() ?: "",
             cashEarnings = computedCash.takeIf { it > 0 }?.toInputString() ?: "",
             cardEarnings = computedCard.takeIf { it > 0 }?.toInputString() ?: "",
-            tips = computedTips.takeIf { it > 0 }?.toInputString() ?: ""
+            tips = computedTips.takeIf { it > 0 }?.toInputString() ?: "",
+            trips = tripsCount?.takeIf { it >= 0 }?.toString() ?: ""
         )
     }
 }

--- a/app/src/main/java/com/fleetmanager/ui/viewmodel/AddEntryViewModel.kt
+++ b/app/src/main/java/com/fleetmanager/ui/viewmodel/AddEntryViewModel.kt
@@ -1,23 +1,61 @@
 package com.fleetmanager.ui.viewmodel
 
 import android.net.Uri
-import com.fleetmanager.domain.model.DailyEntry
-import com.fleetmanager.domain.model.Driver
-import com.fleetmanager.domain.model.Vehicle
+import com.fleetmanager.data.dto.UserDto
 import com.fleetmanager.data.remote.FirestoreService
 import com.fleetmanager.data.remote.UserFirestoreService
 import com.fleetmanager.data.remote.VehicleFirestoreService
-import com.fleetmanager.data.dto.UserDto
+import com.fleetmanager.domain.model.DailyEntry
+import com.fleetmanager.domain.model.Driver
+import com.fleetmanager.domain.model.ProviderEarning
+import com.fleetmanager.domain.model.ProviderType
 import com.fleetmanager.domain.model.UserRole
+import com.fleetmanager.domain.model.Vehicle
 import com.fleetmanager.domain.usecase.GetAllEntriesRealtimeUseCase
 import com.fleetmanager.domain.usecase.SaveDailyEntryUseCase
 import com.fleetmanager.domain.validation.InputValidator
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.collect
 import java.text.SimpleDateFormat
-import java.util.*
-import javax.inject.Inject
 import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import java.util.UUID
+import javax.inject.Inject
+
+private fun Double.toInputString(): String {
+    return if (this % 1.0 == 0.0) {
+        String.format(Locale.US, "%.0f", this)
+    } else {
+        String.format(Locale.US, "%.2f", this)
+    }
+}
+
+data class ProviderInputState(
+    val hoursOnline: String = "",
+    val cashEarnings: String = "",
+    val cardEarnings: String = "",
+    val tips: String = "",
+    val hoursOnlineError: String? = null,
+    val cashEarningsError: String? = null,
+    val cardEarningsError: String? = null,
+    val tipsError: String? = null
+) {
+    fun totalAmount(): Double {
+        val cash = cashEarnings.toDoubleOrNull() ?: 0.0
+        val card = cardEarnings.toDoubleOrNull() ?: 0.0
+        val tipsValue = tips.toDoubleOrNull() ?: 0.0
+        return cash + card + tipsValue
+    }
+
+    fun hasErrors(): Boolean {
+        return listOf(hoursOnlineError, cashEarningsError, cardEarningsError, tipsError).any { it != null }
+    }
+}
 
 data class AddEntryUiState(
     val drivers: List<Driver> = emptyList(),
@@ -27,9 +65,6 @@ data class AddEntryUiState(
     val driverInput: String = "",
     val vehicleInput: String = "",
     val date: Date,
-    val uberEarnings: String = "",
-    val yangoEarnings: String = "",
-    val privateJobsEarnings: String = "",
     val notes: String = "",
     val photoUri: Uri? = null,
     val photoUris: List<Uri> = emptyList(),
@@ -37,12 +72,14 @@ data class AddEntryUiState(
     val driverDropdownExpanded: Boolean = false,
     val vehicleDropdownExpanded: Boolean = false,
     val showDatePicker: Boolean = false,
+    val odometer: String = "",
+    val odometerError: String? = null,
+    val uberInput: ProviderInputState = ProviderInputState(),
+    val yangoInput: ProviderInputState = ProviderInputState(),
+    val privateInput: ProviderInputState = ProviderInputState(),
     val isLoading: Boolean = false,
     val isSaved: Boolean = false,
     val error: String? = null,
-    val uberEarningsError: String? = null,
-    val yangoEarningsError: String? = null,
-    val privateJobsEarningsError: String? = null,
     val notesError: String? = null,
     val userRole: UserRole? = null,
     val currentUserProfile: UserDto? = null,
@@ -51,26 +88,25 @@ data class AddEntryUiState(
     val createdAt: Date? = null,
     val isEditing: Boolean = false
 ) {
+    private fun providerInputs(): List<ProviderInputState> = listOf(uberInput, yangoInput, privateInput)
+
+    val hasProviderTotals: Boolean
+        get() = providerInputs().any { it.totalAmount() > 0.0 }
+
     val canSave: Boolean
         get() = driverInput.isNotBlank() &&
-                vehicleInput.isNotBlank() &&
-                uberEarningsError == null &&
-                yangoEarningsError == null &&
-                privateJobsEarningsError == null &&
-                notesError == null &&
-                (uberEarnings.isNotBlank() || yangoEarnings.isNotBlank() || privateJobsEarnings.isNotBlank())
-    
+            vehicleInput.isNotBlank() &&
+            !hasValidationErrors &&
+            hasProviderTotals
+
     val hasValidationErrors: Boolean
-        get() = uberEarningsError != null || 
-                yangoEarningsError != null || 
-                privateJobsEarningsError != null || 
-                notesError != null
-    
-    // Driver names from Firestore only
+        get() = notesError != null ||
+            odometerError != null ||
+            providerInputs().any { it.hasErrors() }
+
     val allDriverNames: List<String>
         get() = drivers.map { it.name }.sorted()
-    
-    // Vehicle names from Firestore only
+
     val allVehicleNames: List<String>
         get() = vehicles.map { it.displayName }.sorted()
 }
@@ -91,32 +127,24 @@ class AddEntryViewModel @Inject constructor(
     )
 
     private var notificationPrefillHandled = false
-    
-    /**
-     * Calculate the default date based on the 2PM rule:
-     * - If current time is before 2:00 PM, use yesterday's date
-     * - Otherwise, use today's date
-     */
+
     private fun getDefaultDate(): Date {
         val now = Calendar.getInstance()
         val currentHour = now.get(Calendar.HOUR_OF_DAY)
-        
-        return if (currentHour < 14) { // Before 2:00 PM (14:00)
-            // Use yesterday's date
+
+        return if (currentHour < 14) {
             now.add(Calendar.DAY_OF_MONTH, -1)
             now.time
         } else {
-            // Use today's date
             now.time
         }
     }
-    
+
     init {
         loadFirestoreData()
         loadUserProfile()
     }
-    
-    
+
     private fun loadFirestoreData() {
         executeAsync(
             onError = { error ->
@@ -159,9 +187,7 @@ class AddEntryViewModel @Inject constructor(
 
     private fun loadUserProfile() {
         executeAsync(
-            onError = { error ->
-                // Don't show error for user profile loading, just continue
-            }
+            onError = { }
         ) {
             userFirestoreService.getCurrentUserProfile().collect { userProfile ->
                 updateState { currentState ->
@@ -193,81 +219,103 @@ class AddEntryViewModel @Inject constructor(
         }
         return role == UserRole.DRIVER || role == UserRole.MANAGER
     }
-    
+
     fun selectDriver(driver: Driver) {
         updateState { it.copy(selectedDriver = driver, driverInput = driver.name) }
     }
-    
+
     fun selectVehicle(vehicle: Vehicle) {
         updateState { it.copy(selectedVehicle = vehicle, vehicleInput = vehicle.displayName) }
     }
-    
+
     fun updateDriverInput(input: String) {
-        updateState { 
+        updateState {
             it.copy(
                 driverInput = input,
-                selectedDriver = null // We no longer maintain selectedDriver state
-            ) 
+                selectedDriver = null
+            )
         }
     }
-    
+
     fun updateVehicleInput(input: String) {
-        updateState { 
+        updateState {
             it.copy(
                 vehicleInput = input,
                 selectedVehicle = it.vehicles.find { vehicle -> vehicle.displayName == input }
-            ) 
+            )
         }
     }
-    
-    fun updateUberEarnings(value: String) {
+
+    fun updateOdometer(value: String) {
         val sanitized = validator.sanitizeNumericInput(value)
-        val error = validator.validateEarnings(sanitized, "Uber earnings").getErrorMessage()
-        updateState { 
+        val error = validator.validateOptionalDecimal(sanitized, "Odometer").getErrorMessage()
+        updateState {
             it.copy(
-                uberEarnings = sanitized,
-                uberEarningsError = error
-            ) 
+                odometer = sanitized,
+                odometerError = error
+            )
         }
     }
-    
-    fun updateYangoEarnings(value: String) {
+
+    fun updateProviderHours(providerType: ProviderType, value: String) {
         val sanitized = validator.sanitizeNumericInput(value)
-        val error = validator.validateEarnings(sanitized, "Yango earnings").getErrorMessage()
-        updateState { 
-            it.copy(
-                yangoEarnings = sanitized,
-                yangoEarningsError = error
-            ) 
+        val error = validator.validateOptionalHours(sanitized, "${providerType.displayName()} hours online").getErrorMessage()
+        updateProviderState(providerType) { providerState ->
+            providerState.copy(
+                hoursOnline = sanitized,
+                hoursOnlineError = error
+            )
         }
     }
-    
-    fun updatePrivateJobsEarnings(value: String) {
+
+    fun updateProviderCash(providerType: ProviderType, value: String) {
         val sanitized = validator.sanitizeNumericInput(value)
-        val error = validator.validateEarnings(sanitized, "Private jobs earnings").getErrorMessage()
-        updateState { 
-            it.copy(
-                privateJobsEarnings = sanitized,
-                privateJobsEarningsError = error
-            ) 
+        val error = validator.validateOptionalEarnings(sanitized, "${providerType.displayName()} cash").getErrorMessage()
+        updateProviderState(providerType) { providerState ->
+            providerState.copy(
+                cashEarnings = sanitized,
+                cashEarningsError = error
+            )
         }
     }
-    
+
+    fun updateProviderCard(providerType: ProviderType, value: String) {
+        val sanitized = validator.sanitizeNumericInput(value)
+        val error = validator.validateOptionalEarnings(sanitized, "${providerType.displayName()} card").getErrorMessage()
+        updateProviderState(providerType) { providerState ->
+            providerState.copy(
+                cardEarnings = sanitized,
+                cardEarningsError = error
+            )
+        }
+    }
+
+    fun updateProviderTips(providerType: ProviderType, value: String) {
+        val sanitized = validator.sanitizeNumericInput(value)
+        val error = validator.validateOptionalEarnings(sanitized, "${providerType.displayName()} tips").getErrorMessage()
+        updateProviderState(providerType) { providerState ->
+            providerState.copy(
+                tips = sanitized,
+                tipsError = error
+            )
+        }
+    }
+
     fun updateNotes(value: String) {
         val sanitized = validator.sanitizeText(value)
         val error = validator.validateNotes(sanitized).getErrorMessage()
-        updateState { 
+        updateState {
             it.copy(
                 notes = sanitized,
                 notesError = error
-            ) 
+            )
         }
     }
-    
+
     fun updatePhotoUri(uri: Uri?) {
         updateState { it.copy(photoUri = uri) }
     }
-    
+
     fun addPhotoUris(uris: List<Uri>) {
         updateState { currentState ->
             val currentUris = currentState.photoUris.toMutableList()
@@ -304,11 +352,11 @@ class AddEntryViewModel @Inject constructor(
             return
         }
 
-        executeAsync { 
+        executeAsync {
             val entries = getAllEntriesRealtimeUseCase().firstOrNull().orEmpty()
             val matchingEntry = entries.firstOrNull { entry ->
                 entry.driverId.equals(driverId, ignoreCase = true) &&
-                        isSameDay(entry.date, parsedDate)
+                    isSameDay(entry.date, parsedDate)
             }
 
             matchingEntry?.let { entry ->
@@ -333,25 +381,25 @@ class AddEntryViewModel @Inject constructor(
         val calendarTwo = Calendar.getInstance().apply { time = second }
 
         return calendarOne.get(Calendar.YEAR) == calendarTwo.get(Calendar.YEAR) &&
-                calendarOne.get(Calendar.DAY_OF_YEAR) == calendarTwo.get(Calendar.DAY_OF_YEAR)
+            calendarOne.get(Calendar.DAY_OF_YEAR) == calendarTwo.get(Calendar.DAY_OF_YEAR)
     }
 
     fun updateDate(date: Date) {
         updateState { it.copy(date = date) }
     }
-    
+
     fun toggleDriverDropdown(expanded: Boolean) {
         updateState { it.copy(driverDropdownExpanded = expanded) }
     }
-    
+
     fun toggleVehicleDropdown(expanded: Boolean) {
         updateState { it.copy(vehicleDropdownExpanded = expanded) }
     }
-    
+
     fun toggleDatePicker(show: Boolean) {
         updateState { it.copy(showDatePicker = show) }
     }
-    
+
     fun saveEntry() {
         val currentState = uiState.value
         if (!currentState.canSave) return
@@ -383,42 +431,17 @@ class AddEntryViewModel @Inject constructor(
             val entryIdToUse = currentState.entryId ?: UUID.randomUUID().toString()
             val createdAt = currentState.createdAt ?: now
 
-            // Build providers list from UI state
             val providers = buildList {
-                val uberAmount = currentState.uberEarnings.toDoubleOrNull() ?: 0.0
-                if (uberAmount > 0) {
-                    add(
-                        com.fleetmanager.domain.model.ProviderEarning(
-                            type = com.fleetmanager.domain.model.ProviderType.UBER,
-                            amount = uberAmount,
-                            currency = "AED"
-                        )
-                    )
-                }
-                
-                val yangoAmount = currentState.yangoEarnings.toDoubleOrNull() ?: 0.0
-                if (yangoAmount > 0) {
-                    add(
-                        com.fleetmanager.domain.model.ProviderEarning(
-                            type = com.fleetmanager.domain.model.ProviderType.YANGO,
-                            amount = yangoAmount,
-                            currency = "AED"
-                        )
-                    )
-                }
-                
-                val privateAmount = currentState.privateJobsEarnings.toDoubleOrNull() ?: 0.0
-                if (privateAmount > 0) {
-                    add(
-                        com.fleetmanager.domain.model.ProviderEarning(
-                            type = com.fleetmanager.domain.model.ProviderType.PRIVATE,
-                            amount = privateAmount,
-                            currency = "AED"
-                        )
-                    )
-                }
+                currentState.uberInput.toProviderEarning(ProviderType.UBER)?.let { add(it) }
+                currentState.yangoInput.toProviderEarning(ProviderType.YANGO)?.let { add(it) }
+                currentState.privateInput.toProviderEarning(ProviderType.PRIVATE)?.let { add(it) }
             }
-            
+
+            if (providers.isEmpty()) {
+                updateState { it.copy(isLoading = false, error = "Please add earnings for at least one provider") }
+                return@executeAsync
+            }
+
             val entry = DailyEntry(
                 id = entryIdToUse,
                 userId = currentState.userId,
@@ -430,6 +453,7 @@ class AddEntryViewModel @Inject constructor(
                 providers = providers,
                 notes = currentState.notes,
                 photoUrls = currentState.existingPhotoUrls,
+                odometer = currentState.odometer.toDoubleOrNull(),
                 createdAt = createdAt,
                 updatedAt = now
             )
@@ -472,12 +496,15 @@ class AddEntryViewModel @Inject constructor(
                             date = entry.date,
                             driverInput = entry.driverName,
                             vehicleInput = entry.vehicle,
-                            uberEarnings = entry.uberEarnings.takeIf { it != 0.0 }?.toString() ?: "",
-                            yangoEarnings = entry.yangoEarnings.takeIf { it != 0.0 }?.toString() ?: "",
-                            privateJobsEarnings = entry.privateJobsEarnings.takeIf { it != 0.0 }?.toString() ?: "",
+                            uberInput = entry.providerFor(ProviderType.UBER)?.toInputState() ?: ProviderInputState(),
+                            yangoInput = entry.providerFor(ProviderType.YANGO)?.toInputState() ?: ProviderInputState(),
+                            privateInput = entry.providerFor(ProviderType.PRIVATE)?.toInputState() ?: ProviderInputState(),
+                            odometer = entry.odometer?.let { value -> value.toInputString() } ?: "",
                             notes = entry.notes,
                             existingPhotoUrls = entry.photoUrls,
                             createdAt = entry.createdAt,
+                            odometerError = null,
+                            notesError = null,
                             error = null,
                             isSaved = false
                         )
@@ -486,5 +513,61 @@ class AddEntryViewModel @Inject constructor(
                 it.copy(error = "Entry not found")
             }
         }
+    }
+
+    private fun updateProviderState(providerType: ProviderType, transform: (ProviderInputState) -> ProviderInputState) {
+        updateState { currentState ->
+            when (providerType) {
+                ProviderType.UBER -> currentState.copy(uberInput = transform(currentState.uberInput))
+                ProviderType.YANGO -> currentState.copy(yangoInput = transform(currentState.yangoInput))
+                ProviderType.PRIVATE -> currentState.copy(privateInput = transform(currentState.privateInput))
+                else -> currentState
+            }
+        }
+    }
+
+    private fun ProviderType.displayName(): String {
+        return when (this) {
+            ProviderType.UBER -> "Uber"
+            ProviderType.YANGO -> "Yango"
+            ProviderType.PRIVATE -> "Private"
+            ProviderType.CAREEM -> "Careem"
+            ProviderType.OTHER -> "Other"
+        }
+    }
+
+    private fun ProviderInputState.toProviderEarning(type: ProviderType): ProviderEarning? {
+        val cash = cashEarnings.toDoubleOrNull() ?: 0.0
+        val card = cardEarnings.toDoubleOrNull() ?: 0.0
+        val tipsValue = tips.toDoubleOrNull() ?: 0.0
+        val total = cash + card + tipsValue
+        if (total <= 0.0) {
+            return null
+        }
+
+        val hours = hoursOnline.toDoubleOrNull()
+
+        return ProviderEarning(
+            type = type,
+            amount = total,
+            cardAmount = card,
+            cashAmount = cash,
+            tipsAmount = tipsValue,
+            hoursOnline = hours,
+            currency = "AED"
+        )
+    }
+
+    private fun ProviderEarning.toInputState(): ProviderInputState {
+        val computedCard = if (cardAmount > 0) cardAmount else if (!hasBreakdown && amount > 0) amount else 0.0
+        val computedCash = if (cashAmount > 0) cashAmount else 0.0
+        val computedTips = if (tipsAmount > 0) tipsAmount else 0.0
+
+        return ProviderInputState(
+            hoursOnline = hoursOnline?.takeIf { it > 0 }?.toInputString() ?: "",
+            cashEarnings = computedCash.takeIf { it > 0 }?.toInputString() ?: "",
+            cardEarnings = computedCard.takeIf { it > 0 }?.toInputString() ?: "",
+            tips = computedTips.takeIf { it > 0 }?.toInputString() ?: ""
+        )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="cash_earnings">Cash</string>
     <string name="card_earnings">Card</string>
     <string name="tips">Tips</string>
+    <string name="trips">Trips</string>
     <string name="provider_section">%1$s Earnings</string>
     <string name="add_provider_earnings_hint">Add earnings for at least one provider to save this entry.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,8 @@
     <string name="entries">Entries</string>
     <string name="driver_name">Driver Name</string>
     <string name="vehicle">Vehicle</string>
+    <string name="uber">Uber</string>
+    <string name="yango">Yango</string>
     <string name="uber_earnings">Uber Earnings</string>
     <string name="yango_earnings">Yango Earnings</string>
     <string name="private_jobs">Private Jobs</string>
@@ -25,4 +27,11 @@
     <string name="total_earnings">Total Earnings</string>
     <string name="camera_permission_required">Camera permission is required to take photos</string>
     <string name="storage_permission_required">Storage permission is required to select photos</string>
+    <string name="odometer">Odometer</string>
+    <string name="hours_online">Hours Online</string>
+    <string name="cash_earnings">Cash</string>
+    <string name="card_earnings">Card</string>
+    <string name="tips">Tips</string>
+    <string name="provider_section">%1$s Earnings</string>
+    <string name="add_provider_earnings_hint">Add earnings for at least one provider to save this entry.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add odometer and provider earnings breakdown inputs to the add income form
- extend view model, validation, and domain models to persist hours, cash, card, and tip values per provider
- update Firestore, Room converters, and strings to handle the new data shape

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b59b7f988323af9a7c521e36f57d